### PR TITLE
[BE]feat: ML2 Vision API 엔드포인트 연결 (dummy task)

### DIFF
--- a/backend/app/apis/v1/__init__.py
+++ b/backend/app/apis/v1/__init__.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter
 
 from app.apis.v1.auth_routers import auth_router
 from app.apis.v1.user_routers import user_router
+from app.apis.v1.ai_vision_routers import ai_vision_router
 
 v1_routers = APIRouter(prefix="/api/v1")
 v1_routers.include_router(auth_router)
 v1_routers.include_router(user_router)
+v1_routers.include_router(ai_vision_router)

--- a/backend/app/apis/v1/ai_vision_routers.py
+++ b/backend/app/apis/v1/ai_vision_routers.py
@@ -1,0 +1,141 @@
+"""
+ML2 Vision API 라우터 — 식단 분석 / 운동 캡처 인증 엔드포인트
+
+위치: backend/app/apis/v1/ai_vision_routers.py
+역할: 이미지 데이터 수신 → AIVisionService로 Celery 태스크 호출 → task_id 반환
+
+패턴:auth_routers.py 패턴 준수
+  - APIRouter with prefix & tags
+  - JSONResponse 직접 반환
+  - Swagger 문서화 (summary, description, responses)
+"""
+
+from fastapi import APIRouter, status
+from fastapi.responses import JSONResponse as Response
+
+from app.dtos.ai_vision import (
+    ErrorResponse,
+    ExerciseAnalyzeRequest,
+    MealAnalyzeRequest,
+    TaskResponse,
+    TaskResultResponse,
+)
+from app.services.ai_vision_service import AIVisionService
+
+# /api/v1/ai 경로의 라우터. tags=["ai-vision"]은 Swagger에서 그룹명으로 표시된다.
+ai_vision_router = APIRouter(prefix="/ai", tags=["ai-vision"])
+
+ai_vision_service = AIVisionService()
+
+
+# ══════════════════════════════════════════════
+# 식단 분석
+# ══════════════════════════════════════════════
+
+@ai_vision_router.post(
+    "/meals/free",
+    response_model=TaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="식단 무료 분석 요청 (+100pt)",
+    description="식단 이미지를 제출하면 Celery 태스크로 분석을 시작합니다. "
+                "task_id로 결과를 조회하세요.",
+    responses={
+        202: {"description": "분석 태스크 접수 완료", "model": TaskResponse},
+        400: {"description": "잘못된 요청", "model": ErrorResponse},
+    },
+)
+async def analyze_meal_free(request: MealAnalyzeRequest) -> Response:
+    task_id = ai_vision_service.enqueue_meal_free(
+        image_base64=request.image_base64,
+        media_type=request.media_type,
+        risk_factors=request.risk_factors,
+    )
+    return Response(
+        content=TaskResponse(
+            task_id=task_id,
+            status="PENDING",
+            message="식단 무료 분석이 접수되었습니다.",
+        ).model_dump(),
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+
+
+@ai_vision_router.post(
+    "/meals/paid",
+    response_model=TaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="식단 유료 상세 리포트 (-300pt)",
+    description="포인트를 사용하여 상세 영양 분석 리포트를 받습니다. "
+                "비타민, 미네랄, 나트륨 정보 포함.",
+    responses={
+        202: {"description": "분석 태스크 접수 완료", "model": TaskResponse},
+        400: {"description": "잘못된 요청", "model": ErrorResponse},
+        402: {"description": "포인트 부족", "model": ErrorResponse},
+    },
+)
+async def analyze_meal_paid(request: MealAnalyzeRequest) -> Response:
+    # TODO: 포인트 차감 로직 추가 (user_id 필요 → 인증 미들웨어 연결 후)
+    task_id = ai_vision_service.enqueue_meal_paid(
+        image_base64=request.image_base64,
+        media_type=request.media_type,
+        risk_factors=request.risk_factors,
+    )
+    return Response(
+        content=TaskResponse(
+            task_id=task_id,
+            status="PENDING",
+            message="식단 유료 분석이 접수되었습니다. (-300pt)",
+        ).model_dump(),
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+
+
+# ══════════════════════════════════════════════
+# 운동 캡처 인증
+# ══════════════════════════════════════════════
+
+@ai_vision_router.post(
+    "/exercise",
+    response_model=TaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="운동 캡처 인증 (+100pt)",
+    description="운동 앱 스크린샷을 제출하여 운동 인증을 요청합니다.",
+    responses={
+        202: {"description": "인증 태스크 접수 완료", "model": TaskResponse},
+        400: {"description": "잘못된 요청", "model": ErrorResponse},
+    },
+)
+async def analyze_exercise(request: ExerciseAnalyzeRequest) -> Response:
+    task_id = ai_vision_service.enqueue_exercise(
+        image_base64=request.image_base64,
+        media_type=request.media_type,
+    )
+    return Response(
+        content=TaskResponse(
+            task_id=task_id,
+            status="PENDING",
+            message="운동 캡처 인증이 접수되었습니다.",
+        ).model_dump(),
+        status_code=status.HTTP_202_ACCEPTED,
+    )
+
+
+# ══════════════════════════════════════════════
+# 태스크 결과 조회
+# ══════════════════════════════════════════════
+
+@ai_vision_router.get(
+    "/tasks/{task_id}",
+    response_model=TaskResultResponse,
+    summary="태스크 결과 조회",
+    description="task_id로 Celery 태스크의 상태와 결과를 조회합니다.",
+    responses={
+        200: {"description": "태스크 결과", "model": TaskResultResponse},
+    },
+)
+async def get_task_result(task_id: str) -> Response:
+    result = ai_vision_service.get_task_result(task_id)
+    return Response(
+        content=TaskResultResponse(**result).model_dump(),
+        status_code=status.HTTP_200_OK,
+    )

--- a/backend/app/dtos/ai_vision.py
+++ b/backend/app/dtos/ai_vision.py
@@ -1,0 +1,63 @@
+"""
+ML2 Vision API DTO (Request/Response 스키마)
+
+위치: backend/app/dtos/ai_vision.py
+역할: 식단 분석 / 운동 캡처 인증 엔드포인트의 입출력 형식 정의
+"""
+
+from pydantic import BaseModel, Field
+from typing import Optional, Any
+
+
+# ══════════════════════════════════════════════
+# 공통 응답
+# ══════════════════════════════════════════════
+
+class TaskResponse(BaseModel):
+    """Celery 태스크 접수 응답"""
+    task_id: str = Field(..., description="Celery 태스크 ID (결과 조회용)")
+    status: str = Field(default="PENDING", description="태스크 상태")
+    message: str = Field(..., description="안내 메시지")
+
+
+class TaskResultResponse(BaseModel):
+    """Celery 태스크 결과 조회 응답"""
+    task_id: str
+    status: str = Field(..., description="PENDING | SUCCESS | FAILURE")
+    result: Optional[Any] = Field(default=None, description="태스크 결과 (완료 시)")
+    error: Optional[str] = Field(default=None, description="에러 메시지 (실패 시)")
+
+
+class ErrorResponse(BaseModel):
+    """에러 응답"""
+    detail: str
+
+
+# ══════════════════════════════════════════════
+# 식단 분석 요청
+# ══════════════════════════════════════════════
+
+class MealAnalyzeRequest(BaseModel):
+    """식단 분석 요청 (무료/유료 공용)"""
+    image_base64: str = Field(..., description="이미지 base64 인코딩 문자열")
+    media_type: str = Field(
+        default="image/jpeg",
+        description="이미지 MIME 타입 (image/jpeg, image/png, image/webp, image/gif)",
+    )
+    risk_factors: str = Field(
+        default="",
+        description="사용자 위험 요인 (예: '고혈압, 당뇨')",
+    )
+
+
+# ══════════════════════════════════════════════
+# 운동 캡처 인증 요청
+# ══════════════════════════════════════════════
+
+class ExerciseAnalyzeRequest(BaseModel):
+    """운동 앱 스크린샷 인증 요청"""
+    image_base64: str = Field(..., description="운동 앱 스크린샷 base64 인코딩 문자열")
+    media_type: str = Field(
+        default="image/jpeg",
+        description="이미지 MIME 타입",
+    )

--- a/backend/app/services/ai_vision_service.py
+++ b/backend/app/services/ai_vision_service.py
@@ -1,0 +1,165 @@
+"""
+ML2 Vision API Service — Celery 태스크 호출 및 결과 조회
+
+위치: backend/app/services/ai_vision_service.py
+역할: 라우터에서 받은 데이터 → Celery ml2 큐에 태스크 등록 → task_id 반환
+
+현재: dummy task로 파이프라인 테스트
+나중에: ai.vision.tasks import로 한 줄 교체
+"""
+
+from celery.result import AsyncResult
+from celery import Celery
+import os
+
+# ──────────────────────────────────────────────
+# Celery 앱
+# ──────────────────────────────────────────────
+# 현재: 로컬 테스트용 celery 앱
+# 나중에: from ai.celery_app import celery_app
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+celery_app = Celery(
+    "ai_worker",
+    broker=REDIS_URL,
+    backend=REDIS_URL,
+)
+
+
+# ──────────────────────────────────────────────
+# Dummy Tasks (파이프라인 테스트용)
+# ──────────────────────────────────────────────
+# 실제 교체 시 이 블록 전체 삭제하고 아래 import 활성화:
+#
+#   from ai.vision.tasks import (
+#       analyze_meal_free,
+#       analyze_meal_paid,
+#       analyze_exercise,
+#   )
+
+@celery_app.task(name="dummy.meal_free", queue="ml2")
+def dummy_meal_free(image_base64: str, media_type: str, risk_factors: str = ""):
+    return {
+        "status": "success",
+        "task_name": "식단_무료_분석",
+        "data": {
+            "result": {
+                "food_name": "더미 음식",
+                "calories": 500,
+                "score": 7,
+                "feedback": "더미 응답입니다. Vision API 연결 후 교체됩니다.",
+            },
+            "usage": {"model": "dummy", "tokens": 0},
+        },
+        "error": None,
+    }
+
+
+@celery_app.task(name="dummy.meal_paid", queue="ml2")
+def dummy_meal_paid(image_base64: str, media_type: str, risk_factors: str = ""):
+    return {
+        "status": "success",
+        "task_name": "식단_유료_분석",
+        "data": {
+            "result": {
+                "food_name": "더미 음식",
+                "calories": 500,
+                "score": 7,
+                "feedback": "더미 상세 리포트입니다.",
+                "vitamin_info": "비타민 정보 더미",
+                "mineral_info": "미네랄 정보 더미",
+                "sodium_level": "보통",
+            },
+            "usage": {"model": "dummy", "tokens": 0},
+        },
+        "error": None,
+    }
+
+
+@celery_app.task(name="dummy.exercise", queue="ml2")
+def dummy_exercise(image_base64: str, media_type: str):
+    return {
+        "status": "success",
+        "task_name": "운동_캡처_인증",
+        "data": {
+            "result": {
+                "is_valid": True,
+                "exercise_type": "러닝",
+                "duration_minutes": 30,
+                "feedback": "더미 운동 인증 결과입니다.",
+            },
+        },
+        "error": None,
+    }
+
+
+# ══════════════════════════════════════════════
+# Service 클래스
+# ══════════════════════════════════════════════
+
+class AIVisionService:
+    """
+    ML2 Vision API Celery 태스크 호출 서비스
+
+    교체 가이드:
+        dummy_meal_free.delay(...)  →  analyze_meal_free.delay(...)
+        dummy_meal_paid.delay(...)  →  analyze_meal_paid.delay(...)
+        dummy_exercise.delay(...)   →  analyze_exercise.delay(...)
+    """
+
+    # ── 식단 무료 분석 (+100pt) ──
+
+    @staticmethod
+    def enqueue_meal_free(image_base64: str, media_type: str, risk_factors: str = "") -> str:
+        task = dummy_meal_free.delay(image_base64, media_type, risk_factors)
+        return task.id
+
+    # ── 식단 유료 리포트 (-300pt) ──
+
+    @staticmethod
+    def enqueue_meal_paid(image_base64: str, media_type: str, risk_factors: str = "") -> str:
+        task = dummy_meal_paid.delay(image_base64, media_type, risk_factors)
+        return task.id
+
+    # ── 운동 캡처 인증 (+100pt) ──
+
+    @staticmethod
+    def enqueue_exercise(image_base64: str, media_type: str) -> str:
+        task = dummy_exercise.delay(image_base64, media_type)
+        return task.id
+
+    # ── 결과 조회 (공통) ──
+
+    @staticmethod
+    def get_task_result(task_id: str) -> dict:
+        result = AsyncResult(task_id, app=celery_app)
+
+        if result.state == "PENDING":
+            return {
+                "task_id": task_id,
+                "status": "PENDING",
+                "result": None,
+                "error": None,
+            }
+        elif result.state == "SUCCESS":
+            return {
+                "task_id": task_id,
+                "status": "SUCCESS",
+                "result": result.result,
+                "error": None,
+            }
+        elif result.state == "FAILURE":
+            return {
+                "task_id": task_id,
+                "status": "FAILURE",
+                "result": None,
+                "error": str(result.result),
+            }
+        else:
+            return {
+                "task_id": task_id,
+                "status": result.state,
+                "result": None,
+                "error": None,
+            }


### PR DESCRIPTION
## 📌 작업 내용
- ML2 Vision API FastAPI 엔드포인트 연결 (더미 태스크로 파이프라인 구조 검증)

## 🔄 변경 파일
- app/dtos/ai_vision.py — 요청/응답 DTO 정의
- app/services/ai_vision_service.py — Celery 태스크 호출 서비스 (임시 celery 앱 + 더미 태스크)
- app/apis/v1/ai_vision_routers.py — 식단 분석(무료/유료), 운동 인증, 결과 조회 엔드포인트
- app/apis/v1/__init__.py — ai_vision_router 등록

## ✅ 테스트
- [x] 백엔드: Swagger UI에서 4개 엔드포인트 정상 노출 확인

## 🔗 관련 평가 항목
- 

## 📝 리뷰어에게
-  ai/celery_app.py 통합 확정 후 실제 Vision 태스크 연결 예정!

## 📸 스크린샷 (선택)
