### PR TITLE
[AI] fix: predict.py 모델 경로 환경변수로 변경

### DIFF
--- a/ai/workers/predict.py
+++ b/ai/workers/predict.py
@@ -5,14 +5,10 @@ ML1: XGBoost + SHAP
 
 import os
 
-import joblib
-import numpy as np
-import pandas as pd
-import shap
 
-# ── 모델 로드 (Docker 내: /app/models/, 로컬: ai/models/)
-MODEL_PATH = os.environ.get("ML1_MODEL_PATH", "ai/models/xgboost_model.pkl")
-SCALER_PATH = os.environ.get("ML1_SCALER_PATH", "ai/models/scaler.pkl")
+MODEL_PATH = os.getenv('ML1_MODEL_PATH', 'ai/models/xgboost_model.pkl')
+SCALER_PATH = os.getenv('ML1_SCALER_PATH', 'ai/models/scaler.pkl')
+
 
 model = joblib.load(MODEL_PATH)
 scaler = joblib.load(SCALER_PATH)


### PR DESCRIPTION
## 📌 작업 내용
- 하드코딩된 모델 경로 제거
- os.getenv()로 Docker 환경변수 대응
- 로컬 기본값 유

## 🔄 변경 내용
- 
| 변경 전 | 변경 후 |
|---------|---------|
| `MODEL_PATH = 'ai/models/xgboost_model.pkl'` | `os.getenv('ML1_MODEL_PATH', 'ai/models/xgboost_model.pkl')` |
| `SCALER_PATH = 'ai/models/scaler.pkl'` | `os.getenv('ML1_SCALER_PATH', 'ai/models/scaler.pkl')` |

## ✅ 테스트
- [x] Docker 환경변수 대응
- [ ] BE 연동 테스트
