### PR TITLE
[AI] fix: predict.py import 누락 수정

### DIFF
--- a/ai/workers/predict.py
+++ b/ai/workers/predict.py
@@ -4,7 +4,10 @@ ML1: XGBoost + SHAP
 """
 
 import os
-
+import joblib
+import numpy as np
+import pandas as pd
+import shap
 
 MODEL_PATH = os.getenv('ML1_MODEL_PATH', 'ai/models/xgboost_model.pkl')
 SCALER_PATH = os.getenv('ML1_SCALER_PATH', 'ai/models/scaler.pkl')


### PR DESCRIPTION
## 📌 작업 내용
- `predict.py` 상단 import 누락 수정
- Docker 환경에서 ai-worker 실행 시 발생하던 NameError 해결
## 🔄  수정된 import
```python
import os
import joblib
import numpy as np
import pandas as pd
import shap
```
## ✅ 확인 사항
- [x] Docker compose up 정상 실행 확인
- [x] ai-worker Celery 정상 기동 확인
- [x] ml1.analyze_health 태스크 등록 확인
- [ ] BE 연동 테스트
