### PR TITLE
[BE] refactor: 백엔드 및 AI 워커 안정화

### DIFF
--- a/ai/vision/tasks.py
+++ b/ai/vision/tasks.py
@@ -10,14 +10,36 @@ Vision API Celery Tasks (v2 — 피드백 반영)
 
 import asyncio
 import base64
+import json
 import logging
+import os
+
+import redis as sync_redis
 
 from ai.celery_app import celery_app
-from .meal_service import MealService
-from .exercise_service import ExerciseService
+
 from .client import ALLOWED_MEDIA_TYPES
+from .exercise_service import ExerciseService
+from .meal_service import MealService
 
 logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────
+# Pub/Sub 발행 Redis 클라이언트 (DB 3)
+# ──────────────────────────────────────────────
+_REDIS_BASE = os.getenv("REDIS_URL", "redis://localhost:6379/0").rsplit("/", 1)[0]
+_PUBSUB_REDIS_URL = os.getenv("REDIS_PUBSUB_URL", _REDIS_BASE + "/3")
+_pubsub_redis = sync_redis.from_url(_PUBSUB_REDIS_URL, decode_responses=True)
+
+
+def _publish_result(task_id: str, payload: dict) -> None:
+    """태스크 완료 결과를 Redis Pub/Sub 채널에 발행한다."""
+    channel = f"task:result:{task_id}"
+    try:
+        _pubsub_redis.publish(channel, json.dumps(payload))
+        logger.info("Pub/Sub 발행 완료 - channel: %s", channel)
+    except Exception as pub_err:
+        logger.warning("Pub/Sub 발행 실패 (무시) - %s", pub_err)
 
 # ──────────────────────────────────────────────
 # 서비스 인스턴스 (Worker 프로세스당 1개)
@@ -58,8 +80,8 @@ def validate_input(image_base64: str, media_type: str) -> bytes:
     # 3) base64 디코딩
     try:
         image_bytes = base64.b64decode(image_base64)
-    except Exception:
-        raise InvalidInputError("base64 디코딩 실패 — 이미지 데이터가 손상되었습니다.")
+    except Exception as decode_err:
+        raise InvalidInputError("base64 디코딩 실패 — 이미지 데이터가 손상되었습니다.") from decode_err
 
     # 4) 디코딩된 데이터 크기 검증
     if len(image_bytes) == 0:
@@ -132,11 +154,16 @@ def _run_vision_task(self, task_name: str, image_base64: str, media_type: str, s
     try:
         result = asyncio.run(service_call(image_bytes))
         logger.info(f"[{task_name}] 완료 | task_id={task_id}")
-        return success_response(task_name, task_id, result)
+        response = success_response(task_name, task_id, result)
+
+        # Pub/Sub 발행 (SSE 구독 중인 클라이언트에 실시간 전달)
+        _publish_result(task_id, response)
+
+        return response
 
     except Exception as exc:
         logger.error(f"[{task_name}] API 오류 (retry 시도) | task_id={task_id} | {exc}")
-        raise self.retry(exc=exc)
+        raise self.retry(exc=exc) from exc
 
 
 # ══════════════════════════════════════════════

--- a/ai/workers/predict.py
+++ b/ai/workers/predict.py
@@ -3,19 +3,27 @@
 ML1: XGBoost + SHAP
 """
 
+import logging
 import os
+
 import joblib
 import numpy as np
 import pandas as pd
 import shap
 
+logger = logging.getLogger(__name__)
+
 MODEL_PATH = os.getenv('ML1_MODEL_PATH', 'ai/models/xgboost_model.pkl')
 SCALER_PATH = os.getenv('ML1_SCALER_PATH', 'ai/models/scaler.pkl')
 
-
+logger.info("모델 로딩 시작 - path: %s", MODEL_PATH)
 model = joblib.load(MODEL_PATH)
 scaler = joblib.load(SCALER_PATH)
+logger.info("모델 로딩 완료")
+
+logger.info("SHAP TreeExplainer 초기화 시작")
 explainer = shap.TreeExplainer(model)
+logger.info("SHAP TreeExplainer 초기화 완료")
 
 # ── 상수 정의
 
@@ -217,12 +225,16 @@ def predict(user_data: dict) -> dict:
         }
     """
     # 전처리
+    logger.info("전처리 시작")
     df_input = preprocess(user_data)
+    logger.info("전처리 완료")
 
-    # 예측
+    # 예측 (OMP_NUM_THREADS=1 설정으로 Celery fork 환경 교착 방지)
+    logger.info("XGBoost 예측 시작")
     risk_percent = float(
         model.predict_proba(df_input)[0][1] * 100
     )
+    logger.info("XGBoost 예측 완료 - risk_percent: %.1f", risk_percent)
 
     # 결과 조합
     return {

--- a/ai/workers/tasks.py
+++ b/ai/workers/tasks.py
@@ -78,6 +78,7 @@ def analyze_health(self, user_data: dict, nickname: str = "사용자", challenge
 
         # 캐시 저장
         cache_key = _build_cache_key(user_data, nickname, challenge_days)
+        logger.info("cache_key: %s", cache_key)
         try:
             cache_redis.setex(cache_key, CACHE_TTL, json.dumps(result))
             logger.info("ML1 캐시 저장 완료 - key: %s", cache_key)

--- a/ai/workers/tasks.py
+++ b/ai/workers/tasks.py
@@ -16,15 +16,31 @@ from ai.workers.worker import ml1_run
 logger = logging.getLogger(__name__)
 
 # ──────────────────────────────────────────────
-# Redis 캐시 클라이언트 (DB 2번 - ML1 분석 결과 캐시 전용)
+# Redis 클라이언트 설정
+# DB 2: ML1 분석 결과 캐시 (24시간 TTL)
+# DB 3: Pub/Sub 발행 (태스크 완료 실시간 알림)
 # ──────────────────────────────────────────────
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-# DB 1번으로 변경하여 Celery broker(DB 0번)와 분리
-CACHE_REDIS_URL = os.getenv("REDIS_CACHE_URL", REDIS_URL.rsplit("/", 1)[0] + "/2")
+_redis_base = REDIS_URL.rsplit("/", 1)[0]
+
+CACHE_REDIS_URL = os.getenv("REDIS_CACHE_URL", _redis_base + "/2")
+PUBSUB_REDIS_URL = os.getenv("REDIS_PUBSUB_URL", _redis_base + "/3")
+
 cache_redis = redis.from_url(CACHE_REDIS_URL, decode_responses=True)
+pubsub_redis = redis.from_url(PUBSUB_REDIS_URL, decode_responses=True)
 
 # 캐시 TTL: 24시간
 CACHE_TTL = 86400
+
+
+def _publish_result(task_id: str, payload: dict) -> None:
+    """태스크 완료 결과를 Redis Pub/Sub 채널에 발행한다."""
+    channel = f"task:result:{task_id}"
+    try:
+        pubsub_redis.publish(channel, json.dumps(payload))
+        logger.info("Pub/Sub 발행 완료 - channel: %s", channel)
+    except Exception as pub_err:
+        logger.warning("Pub/Sub 발행 실패 (무시) - %s", pub_err)
 
 
 def _build_cache_key(user_data: dict, nickname: str, challenge_days: int) -> str:
@@ -68,14 +84,19 @@ def analyze_health(self, user_data: dict, nickname: str = "사용자", challenge
         except Exception as cache_err:
             logger.warning("ML1 캐시 저장 실패 (무시) - %s", cache_err)
 
-        logger.info("ML1 분석 완료 - task_id: %s", task_id)
-        return {
+        result_payload = {
             "status": "success",
             "task_id": task_id,
             "data": result,
             "error": None,
         }
 
+        # Pub/Sub 발행 (SSE 구독 중인 클라이언트에 실시간 전달)
+        _publish_result(task_id, result_payload)
+
+        logger.info("ML1 분석 완료 - task_id: %s", task_id)
+        return result_payload
+
     except Exception as exc:
         logger.error("ML1 분석 실패 (retry 시도) - task_id: %s, error: %s", task_id, exc)
-        raise self.retry(exc=exc)
+        raise self.retry(exc=exc) from exc

--- a/ai/workers/worker.py
+++ b/ai/workers/worker.py
@@ -4,13 +4,15 @@ ML1: XGBoost 위험도 예측 + ChatGPT 건강 코멘트 생성
 """
 
 import json
+import logging
 import os
+
 from openai import OpenAI
+
 from ai.workers.predict import predict, recalculate_risk  # noqa: F401
 from ai.workers.prompt import SYSTEM_PROMPT, build_user_prompt
 
-
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+logger = logging.getLogger(__name__)
 
 
 # ── ML1 xgboost 함수 (XGBoost 예측)
@@ -20,22 +22,29 @@ def ml1_predict(user_data: dict) -> dict:
     """
     return predict(user_data)
 
+
 # ── ML1 LLM 코멘트 함수
 def ml1_comment(user_info: dict) -> dict:
     """
     위험도 결과 → 건강 코멘트 생성
+    Celery prefork 환경에서 fork-safety 문제 방지를 위해
+    OpenAI 클라이언트를 함수 내부에서 생성
     """
+    # fork된 워커 프로세스마다 독립적인 클라이언트 인스턴스 생성
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     user_prompt = build_user_prompt(user_info)
 
+    logger.info("OpenAI API 호출 시작")
     response = client.chat.completions.create(
         model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": user_prompt}
+            {"role": "user", "content": user_prompt},
         ],
         temperature=0,
-        timeout=60
+        timeout=60,
     )
+    logger.info("OpenAI API 호출 완료")
 
     raw = response.choices[0].message.content
 
@@ -46,14 +55,16 @@ def ml1_comment(user_info: dict) -> dict:
             "evaluation": "건강 데이터를 분석했습니다.",
             "alert": None,
             "missions": [],
-            "encouragement": "오늘도 건강한 하루 보내세요!"
+            "encouragement": "오늘도 건강한 하루 보내세요!",
         }
 
 
 # ── ML1 통합 실행 함수
-def ml1_run(user_data: dict,
-            nickname: str = '사용자',
-            challenge_days: int = 0) -> dict:
+def ml1_run(
+    user_data: dict,
+    nickname: str = "사용자",
+    challenge_days: int = 0,
+) -> dict:
     """
     건강검진 수치 입력 → XGBoost 예측 + ChatGPT 코멘트 생성
 
@@ -69,54 +80,54 @@ def ml1_run(user_data: dict,
         }
     """
     # 1. ML xgboost 예측
+    logger.info("XGBoost 예측 함수 호출 시작")
     predict_result = ml1_predict(user_data)
+    logger.info("XGBoost 예측 함수 호출 완료")
 
     # 2. ML1 LLM 코멘트 생성
     user_info = {
-        'nickname': nickname,
-        'age': user_data['age'],
-        'risk_percent': predict_result['risk_percent'],
-        'risk_grade': predict_result['risk_grade'],
-        'heart_age': predict_result['heart_age'],
-        'top_risk_factors': predict_result['top_risk_factors'],
-        'smoke': user_data['smoke'],
-        'alco': user_data['alco'],
-        'challenge_days': challenge_days
+        "nickname": nickname,
+        "age": user_data["age"],
+        "risk_percent": predict_result["risk_percent"],
+        "risk_grade": predict_result["risk_grade"],
+        "heart_age": predict_result["heart_age"],
+        "top_risk_factors": predict_result["top_risk_factors"],
+        "smoke": user_data["smoke"],
+        "alco": user_data["alco"],
+        "challenge_days": challenge_days,
     }
+    logger.info("OpenAI 코멘트 생성 시작")
     comment_result = ml1_comment(user_info)
+    logger.info("OpenAI 코멘트 생성 완료")
 
     return {
         "ml1_predict": predict_result,
-        "ml1_comment": comment_result
+        "ml1_comment": comment_result,
     }
 
 
 # ── 테스트
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample = {
-        'age': 45,
-        'gender': 1,
-        'height': 165,
-        'weight': 70,
-        'ap_hi': 140,
-        'ap_lo': 90,
-        'cholesterol': 2,
-        'gluc': 1,
-        'smoke': 1,
-        'alco': 0,
-        'active': 0
+        "age": 45,
+        "gender": 1,
+        "height": 165,
+        "weight": 70,
+        "ap_hi": 140,
+        "ap_lo": 90,
+        "cholesterol": 2,
+        "gluc": 1,
+        "smoke": 1,
+        "alco": 0,
+        "active": 0,
     }
 
-    result = ml1_run(
-        sample,
-        nickname='건강이',
-        challenge_days=3
-    )
+    result = ml1_run(sample, nickname="건강이", challenge_days=3)
 
     print("=== ML1 XGBoost 결과 ===")
-    for k, v in result['ml1_predict'].items():
+    for k, v in result["ml1_predict"].items():
         print(f"{k}: {v}")
 
     print("\n=== ML1 LLM 결과 ===")
-    for k, v in result['ml1_comment'].items():
+    for k, v in result["ml1_comment"].items():
         print(f"{k}: {v}")

--- a/backend/app/apis/v1/ai_vision_routers.py
+++ b/backend/app/apis/v1/ai_vision_routers.py
@@ -11,12 +11,10 @@ ML2 Vision API 라우터 — 식단 분석 / 운동 캡처 인증 엔드포인�
 """
 
 import base64
-import json
 from typing import Annotated
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import JSONResponse as Response
-from fastapi.responses import StreamingResponse
 
 from app.dtos.ai_vision import (
     ErrorResponse,
@@ -24,7 +22,7 @@ from app.dtos.ai_vision import (
     TaskResultResponse,
 )
 from app.services.ai_vision_service import AIVisionService
-from app.utils.pubsub import stream_task_result
+from app.utils.pubsub import wait_task_result
 
 # 허용 MIME 타입 (OpenAI Vision API 지원 형식)
 _ALLOWED_MEDIA_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
@@ -188,8 +186,12 @@ async def analyze_exercise(
 @ai_vision_router.get(
     "/tasks/{task_id}",
     response_model=TaskResultResponse,
-    summary="태스크 결과 조회 (폴링)",
-    description="task_id로 Celery 태스크의 상태와 결과를 조회합니다.",
+    summary="태스크 현재 상태 즉시 확인",
+    description=(
+        "태스크의 현재 상태를 즉시 반환한다. "
+        "결과가 없으면 PENDING을 반환하고 연결이 끊긴다. "
+        "실시간 결과 수신이 필요하면 GET /tasks/{task_id}/wait을 사용한다."
+    ),
     responses={
         200: {"description": "태스크 결과", "model": TaskResultResponse},
     },
@@ -203,38 +205,49 @@ async def get_task_result(task_id: str) -> Response:
 
 
 @ai_vision_router.get(
-    "/tasks/{task_id}/stream",
-    summary="태스크 결과 실시간 수신 (SSE)",
+    "/tasks/{task_id}/wait",
+    response_model=TaskResultResponse,
+    summary="태스크 결과 조회 (롱 폴링)",
     description=(
-        "Redis Pub/Sub을 통해 Vision AI 분석 완료 결과를 실시간으로 수신한다.\n\n"
-        "**SSE(Server-Sent Events) 방식**: 연결 후 결과가 도착하면 즉시 수신하고 연결이 종료된다.\n\n"
-        "**이벤트 종류**\n"
-        "- `connected`: 구독 연결 확인 (최초 1회)\n"
-        "- `data`: 분석 완료 결과 (JSON)\n"
-        "- `timeout`: 120초 초과 시 연결 종료\n"
-        "- `error`: 서버 오류\n\n"
-        "**폴링 방식과 비교**: 반복 요청 없이 결과 즉시 수신 가능"
+        "결과가 준비될 때까지 서버에서 최대 30초 대기 후 반환한다.\n\n"
+        "**롱 폴링 방식**\n"
+        "- 결과 도착 즉시 응답 → 클라이언트 연결 유지 불필요\n"
+        "- 30초 내 완료되면 즉시 반환, 타임아웃 시 `PENDING` 반환\n"
+        "- 타임아웃 수신 시 클라이언트가 즉시 재요청\n\n"
+        "**일반 폴링과 차이**\n"
+        "- 일반 폴링: 서버가 즉시 PENDING 반환 → 클라이언트가 N초 후 재요청\n"
+        "- 롱 폴링: 서버가 결과 올 때까지 대기 → 1회 요청으로 결과 수신"
     ),
-    response_class=StreamingResponse,
+    responses={
+        200: {"description": "태스크 결과 또는 PENDING(타임아웃)", "model": TaskResultResponse},
+    },
 )
-async def stream_vision_result(task_id: str) -> StreamingResponse:
-    # 이미 완료된 태스크라면 SSE 없이 즉시 반환
+async def wait_task_result_endpoint(task_id: str) -> Response:
+    # 1. 이미 완료된 결과가 있으면 즉시 반환 (Pub/Sub 구독 불필요)
     result = ai_vision_service.get_task_result(task_id)
     if result.get("status") not in ("PENDING", None):
-
-        async def _immediate():
-            yield f"event: connected\ndata: {json.dumps({'task_id': task_id})}\n\n"
-            yield f"data: {json.dumps(result)}\n\n"
-
-        return StreamingResponse(
-            _immediate(),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        return Response(
+            content=TaskResultResponse(**result).model_dump(),
+            status_code=status.HTTP_200_OK,
         )
 
-    # 대기 중 → Pub/Sub 채널 구독 후 결과 도착 시 SSE 전달
-    return StreamingResponse(
-        stream_task_result(task_id),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    # 2. 아직 처리 중 → Pub/Sub 채널 구독 후 최대 30초 대기
+    data = await wait_task_result(task_id)
+
+    if data is None:
+        # 타임아웃 → PENDING 반환, 클라이언트가 즉시 재요청
+        return Response(
+            content=TaskResultResponse(task_id=task_id, status="PENDING", result=None, error=None).model_dump(),
+            status_code=status.HTTP_200_OK,
+        )
+
+    # 3. 결과 도착 → 즉시 반환
+    return Response(
+        content=TaskResultResponse(
+            task_id=task_id,
+            status=data.get("status", "FAILURE"),
+            result=data.get("data"),
+            error=data.get("error"),
+        ).model_dump(),
+        status_code=status.HTTP_200_OK,
     )

--- a/backend/app/apis/v1/ai_vision_routers.py
+++ b/backend/app/apis/v1/ai_vision_routers.py
@@ -2,25 +2,32 @@
 ML2 Vision API 라우터 — 식단 분석 / 운동 캡처 인증 엔드포인트
 
 위치: backend/app/apis/v1/ai_vision_routers.py
-역할: 이미지 데이터 수신 → AIVisionService로 Celery 태스크 호출 → task_id 반환
+역할: 이미지 파일 수신 → base64 변환 → AIVisionService로 Celery 태스크 호출 → task_id 반환
 
-패턴:auth_routers.py 패턴 준수
-  - APIRouter with prefix & tags
-  - JSONResponse 직접 반환
-  - Swagger 문서화 (summary, description, responses)
+요청 방식: multipart/form-data
+- 이미지: UploadFile (웹/모바일 파일 업로드 그대로 수신)
+- 텍스트 필드: Form 파라미터
+- MIME 타입: UploadFile.content_type에서 자동 감지
 """
 
-from fastapi import APIRouter, status
+import base64
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import JSONResponse as Response
+from fastapi.responses import StreamingResponse
 
 from app.dtos.ai_vision import (
     ErrorResponse,
-    ExerciseAnalyzeRequest,
-    MealAnalyzeRequest,
     TaskResponse,
     TaskResultResponse,
 )
 from app.services.ai_vision_service import AIVisionService
+from app.utils.pubsub import stream_task_result
+
+# 허용 MIME 타입 (OpenAI Vision API 지원 형식)
+_ALLOWED_MEDIA_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 
 # /api/v1/ai 경로의 라우터. tags=["ai-vision"]은 Swagger에서 그룹명으로 표시된다.
 ai_vision_router = APIRouter(prefix="/ai", tags=["ai-vision"])
@@ -28,27 +35,62 @@ ai_vision_router = APIRouter(prefix="/ai", tags=["ai-vision"])
 ai_vision_service = AIVisionService()
 
 
+def _validate_and_encode(image: UploadFile, image_bytes: bytes) -> tuple[str, str]:
+    """
+    이미지 파일 유효성 검사 후 base64 인코딩 반환.
+
+    Returns:
+        (image_base64, media_type) 튜플
+    """
+    media_type = image.content_type or "image/jpeg"
+
+    if media_type not in _ALLOWED_MEDIA_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"지원하지 않는 이미지 형식입니다. 허용 형식: {', '.join(_ALLOWED_MEDIA_TYPES)}",
+        )
+
+    if len(image_bytes) > 20 * 1024 * 1024:  # 20MB 제한
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이미지 크기는 20MB 이하여야 합니다.",
+        )
+
+    image_base64 = base64.b64encode(image_bytes).decode("utf-8")
+    return image_base64, media_type
+
+
 # ══════════════════════════════════════════════
 # 식단 분석
 # ══════════════════════════════════════════════
+
 
 @ai_vision_router.post(
     "/meals/free",
     response_model=TaskResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="식단 무료 분석 요청 (+100pt)",
-    description="식단 이미지를 제출하면 Celery 태스크로 분석을 시작합니다. "
-                "task_id로 결과를 조회하세요.",
+    description=(
+        "식단 이미지를 multipart/form-data로 제출하면 Celery 태스크로 분석을 시작합니다. "
+        "task_id로 결과를 조회하세요.\n\n"
+        "**지원 형식:** JPEG, PNG, WebP, GIF (최대 20MB)"
+    ),
     responses={
         202: {"description": "분석 태스크 접수 완료", "model": TaskResponse},
-        400: {"description": "잘못된 요청", "model": ErrorResponse},
+        400: {"description": "잘못된 요청 (지원하지 않는 형식 / 크기 초과)", "model": ErrorResponse},
     },
 )
-async def analyze_meal_free(request: MealAnalyzeRequest) -> Response:
+async def analyze_meal_free(
+    image: Annotated[UploadFile, File(description="식단 이미지 파일 (JPEG, PNG, WebP, GIF)")],
+    risk_factors: Annotated[str, Form(description="사용자 위험 요인 (예: 고혈압, 당뇨)")] = "",
+) -> Response:
+    image_bytes = await image.read()
+    image_base64, media_type = _validate_and_encode(image, image_bytes)
+
     task_id = ai_vision_service.enqueue_meal_free(
-        image_base64=request.image_base64,
-        media_type=request.media_type,
-        risk_factors=request.risk_factors,
+        image_base64=image_base64,
+        media_type=media_type,
+        risk_factors=risk_factors,
     )
     return Response(
         content=TaskResponse(
@@ -65,20 +107,29 @@ async def analyze_meal_free(request: MealAnalyzeRequest) -> Response:
     response_model=TaskResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="식단 유료 상세 리포트 (-300pt)",
-    description="포인트를 사용하여 상세 영양 분석 리포트를 받습니다. "
-                "비타민, 미네랄, 나트륨 정보 포함.",
+    description=(
+        "포인트를 사용하여 상세 영양 분석 리포트를 받습니다. "
+        "비타민, 미네랄, 나트륨 정보 포함.\n\n"
+        "**지원 형식:** JPEG, PNG, WebP, GIF (최대 20MB)"
+    ),
     responses={
         202: {"description": "분석 태스크 접수 완료", "model": TaskResponse},
-        400: {"description": "잘못된 요청", "model": ErrorResponse},
+        400: {"description": "잘못된 요청 (지원하지 않는 형식 / 크기 초과)", "model": ErrorResponse},
         402: {"description": "포인트 부족", "model": ErrorResponse},
     },
 )
-async def analyze_meal_paid(request: MealAnalyzeRequest) -> Response:
+async def analyze_meal_paid(
+    image: Annotated[UploadFile, File(description="식단 이미지 파일 (JPEG, PNG, WebP, GIF)")],
+    risk_factors: Annotated[str, Form(description="사용자 위험 요인 (예: 고혈압, 당뇨)")] = "",
+) -> Response:
     # TODO: 포인트 차감 로직 추가 (user_id 필요 → 인증 미들웨어 연결 후)
+    image_bytes = await image.read()
+    image_base64, media_type = _validate_and_encode(image, image_bytes)
+
     task_id = ai_vision_service.enqueue_meal_paid(
-        image_base64=request.image_base64,
-        media_type=request.media_type,
-        risk_factors=request.risk_factors,
+        image_base64=image_base64,
+        media_type=media_type,
+        risk_factors=risk_factors,
     )
     return Response(
         content=TaskResponse(
@@ -94,21 +145,30 @@ async def analyze_meal_paid(request: MealAnalyzeRequest) -> Response:
 # 운동 캡처 인증
 # ══════════════════════════════════════════════
 
+
 @ai_vision_router.post(
     "/exercise",
     response_model=TaskResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="운동 캡처 인증 (+100pt)",
-    description="운동 앱 스크린샷을 제출하여 운동 인증을 요청합니다.",
+    description=(
+        "운동 앱 스크린샷을 multipart/form-data로 제출하여 운동 인증을 요청합니다.\n\n"
+        "**지원 형식:** JPEG, PNG, WebP, GIF (최대 20MB)"
+    ),
     responses={
         202: {"description": "인증 태스크 접수 완료", "model": TaskResponse},
-        400: {"description": "잘못된 요청", "model": ErrorResponse},
+        400: {"description": "잘못된 요청 (지원하지 않는 형식 / 크기 초과)", "model": ErrorResponse},
     },
 )
-async def analyze_exercise(request: ExerciseAnalyzeRequest) -> Response:
+async def analyze_exercise(
+    image: Annotated[UploadFile, File(description="운동 앱 스크린샷 파일 (JPEG, PNG, WebP, GIF)")],
+) -> Response:
+    image_bytes = await image.read()
+    image_base64, media_type = _validate_and_encode(image, image_bytes)
+
     task_id = ai_vision_service.enqueue_exercise(
-        image_base64=request.image_base64,
-        media_type=request.media_type,
+        image_base64=image_base64,
+        media_type=media_type,
     )
     return Response(
         content=TaskResponse(
@@ -124,10 +184,11 @@ async def analyze_exercise(request: ExerciseAnalyzeRequest) -> Response:
 # 태스크 결과 조회
 # ══════════════════════════════════════════════
 
+
 @ai_vision_router.get(
     "/tasks/{task_id}",
     response_model=TaskResultResponse,
-    summary="태스크 결과 조회",
+    summary="태스크 결과 조회 (폴링)",
     description="task_id로 Celery 태스크의 상태와 결과를 조회합니다.",
     responses={
         200: {"description": "태스크 결과", "model": TaskResultResponse},
@@ -138,4 +199,42 @@ async def get_task_result(task_id: str) -> Response:
     return Response(
         content=TaskResultResponse(**result).model_dump(),
         status_code=status.HTTP_200_OK,
+    )
+
+
+@ai_vision_router.get(
+    "/tasks/{task_id}/stream",
+    summary="태스크 결과 실시간 수신 (SSE)",
+    description=(
+        "Redis Pub/Sub을 통해 Vision AI 분석 완료 결과를 실시간으로 수신한다.\n\n"
+        "**SSE(Server-Sent Events) 방식**: 연결 후 결과가 도착하면 즉시 수신하고 연결이 종료된다.\n\n"
+        "**이벤트 종류**\n"
+        "- `connected`: 구독 연결 확인 (최초 1회)\n"
+        "- `data`: 분석 완료 결과 (JSON)\n"
+        "- `timeout`: 120초 초과 시 연결 종료\n"
+        "- `error`: 서버 오류\n\n"
+        "**폴링 방식과 비교**: 반복 요청 없이 결과 즉시 수신 가능"
+    ),
+    response_class=StreamingResponse,
+)
+async def stream_vision_result(task_id: str) -> StreamingResponse:
+    # 이미 완료된 태스크라면 SSE 없이 즉시 반환
+    result = ai_vision_service.get_task_result(task_id)
+    if result.get("status") not in ("PENDING", None):
+
+        async def _immediate():
+            yield f"event: connected\ndata: {json.dumps({'task_id': task_id})}\n\n"
+            yield f"data: {json.dumps(result)}\n\n"
+
+        return StreamingResponse(
+            _immediate(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    # 대기 중 → Pub/Sub 채널 구독 후 결과 도착 시 SSE 전달
+    return StreamingResponse(
+        stream_task_result(task_id),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/backend/app/apis/v1/analysis_routers.py
+++ b/backend/app/apis/v1/analysis_routers.py
@@ -11,6 +11,7 @@ from app.dependencies.security import get_request_user
 from app.dtos.analysis import AnalysisResultResponse, AnalysisTaskResponse, GuestAnalysisRequest
 from app.models.users import User
 from app.services.analysis import HealthAnalysisService
+from app.utils.pubsub import wait_task_result
 
 # /api/v1/health/analysis 경로의 라우터. AI 건강 분석 API를 담당한다.
 analysis_router = APIRouter(prefix="/health/analysis", tags=["analysis"])
@@ -24,11 +25,11 @@ analysis_router = APIRouter(prefix="/health/analysis", tags=["analysis"])
     description=(
         "로그인 없이 건강 수치를 직접 입력하여 심혈관 위험도 예측 및 건강 코멘트를 요청한다. "
         "캐시 히트 시 즉시 결과를 반환하고, 캐시 미스 시 task_id를 반환한다. "
-        "결과 조회는 GET /{task_id} 엔드포인트를 사용한다."
+        "결과 조회는 GET /{task_id}/wait 엔드포인트를 사용한다."
     ),
 )
 async def request_guest_analysis(
-    data: GuestAnalysisRequest,  # 요청 body에서 건강 수치를 직접 받음 (인증 불필요)
+    data: GuestAnalysisRequest,
     session: Annotated[AsyncSession, Depends(get_db_session)],
     redis: Annotated[Redis, Depends(get_redis)],
 ) -> Response:
@@ -44,14 +45,15 @@ async def request_guest_analysis(
     summary="AI 건강 분석 요청",
     description=(
         "건강검진 기록 ID를 기반으로 심혈관 위험도 예측 및 건강 코멘트를 요청한다. "
-        "캐시 히트 시 즉시 결과를 반환하고, 캐시 미스 시 task_id를 반환한다."
+        "캐시 히트 시 즉시 결과를 반환하고, 캐시 미스 시 task_id를 반환한다. "
+        "결과 조회는 GET /{task_id}/wait 엔드포인트를 사용한다."
     ),
 )
 async def request_analysis(
-    record_id: int,  # URL 경로에서 건강검진 기록 ID를 받음
-    user: Annotated[User, Depends(get_request_user)],  # JWT 토큰으로 현재 로그인 사용자 확인
-    session: Annotated[AsyncSession, Depends(get_db_session)],  # DB 세션 자동 주입
-    redis: Annotated[Redis, Depends(get_redis)],  # Redis 클라이언트 주입
+    record_id: int,
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
 ) -> Response:
     service = HealthAnalysisService(session, redis)
     result = await service.request_analysis(record_id, user)
@@ -62,14 +64,67 @@ async def request_analysis(
     "/{task_id}",
     response_model=AnalysisResultResponse,
     status_code=status.HTTP_200_OK,
-    summary="AI 분석 결과 조회",
-    description="비동기 AI 분석 작업의 결과를 조회한다. 작업이 완료되면 분석 결과를, 미완료 시 pending 상태를 반환한다.",
+    summary="AI 분석 현재 상태 즉시 확인",
+    description=(
+        "태스크의 현재 상태를 즉시 반환한다. "
+        "결과가 없으면 pending을 반환하고 연결이 끊긴다. "
+        "실시간 결과 수신이 필요하면 GET /{task_id}/wait을 사용한다."
+    ),
 )
 async def get_analysis_result(
-    task_id: str,  # URL 경로에서 Celery task ID를 받음
+    task_id: str,
     session: Annotated[AsyncSession, Depends(get_db_session)],
     redis: Annotated[Redis, Depends(get_redis)],
 ) -> Response:
     service = HealthAnalysisService(session, redis)
     result = await service.get_analysis_result(task_id)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@analysis_router.get(
+    "/{task_id}/wait",
+    response_model=AnalysisResultResponse,
+    status_code=status.HTTP_200_OK,
+    summary="AI 분석 결과 조회 (롱 폴링)",
+    description=(
+        "결과가 준비될 때까지 서버에서 최대 30초 대기 후 반환한다.\n\n"
+        "**롱 폴링 방식**\n"
+        "- 결과 도착 즉시 응답 → 클라이언트 연결 유지 불필요\n"
+        "- 30초 내 완료되면 즉시 반환, 타임아웃 시 `pending` 반환\n"
+        "- 타임아웃 수신 시 클라이언트가 즉시 재요청\n\n"
+        "**일반 폴링과 차이**\n"
+        "- 일반 폴링: 서버가 즉시 pending 반환 → 클라이언트가 N초 후 재요청\n"
+        "- 롱 폴링: 서버가 결과 올 때까지 대기 → 1회 요청으로 결과 수신"
+    ),
+)
+async def wait_analysis_result(
+    task_id: str,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
+) -> Response:
+    service = HealthAnalysisService(session, redis)
+
+    # 1. 이미 완료된 결과가 있으면 즉시 반환 (Pub/Sub 구독 불필요)
+    result = await service.get_analysis_result(task_id)
+    if result.status != "pending":
+        return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+    # 2. 아직 처리 중 → Pub/Sub 채널 구독 후 최대 30초 대기
+    data = await wait_task_result(task_id)
+
+    if data is None:
+        # 타임아웃 → pending 반환, 클라이언트가 즉시 재요청
+        return Response(
+            AnalysisResultResponse(status="pending").model_dump(),
+            status_code=status.HTTP_200_OK,
+        )
+
+    # 3. 결과 도착 → 즉시 반환
+    return Response(
+        AnalysisResultResponse(
+            status=data.get("status", "failed"),
+            data=data.get("data"),
+            error=data.get("error"),
+        ).model_dump(),
+        status_code=status.HTTP_200_OK,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,9 +41,11 @@ class Config(BaseSettings):
     # DB 0: Celery Broker  (task 대기열)
     # DB 1: Celery Backend (task 완료 결과 저장)
     # DB 2: ML1 Cache      (분석 결과 캐시, 24시간 TTL)
+    # DB 3: Pub/Sub        (태스크 완료 실시간 알림, SSE 스트리밍용)
     CELERY_BROKER_URL: str = "redis://localhost:6379/0"
     CELERY_BACKEND_URL: str = "redis://localhost:6379/1"
     REDIS_CACHE_URL: str = "redis://localhost:6379/2"
+    REDIS_PUBSUB_URL: str = "redis://localhost:6379/3"
 
     # CORS 허용 도메인 (쉼표 구분 문자열)
     CORS_ORIGINS: str = "http://localhost:5173,https://frontend-one-omega-59.vercel.app"

--- a/backend/app/dependencies/security.py
+++ b/backend/app/dependencies/security.py
@@ -18,7 +18,9 @@ async def get_request_user(
 ) -> User:
     token = credential.credentials
     verified = JwtService().verify_jwt(token=token, token_type="access")
-    user_id = verified.payload["user_id"]
+    user_id = verified.payload.get("id")
+    if user_id is None:
+        raise HTTPException(detail="Authenticate Failed.", status_code=status.HTTP_401_UNAUTHORIZED)
     user = await UserRepository(session).get_user(user_id)
     if not user or user.is_deleted:
         raise HTTPException(detail="Authenticate Failed.", status_code=status.HTTP_401_UNAUTHORIZED)

--- a/backend/app/dtos/ai_vision.py
+++ b/backend/app/dtos/ai_vision.py
@@ -3,18 +3,24 @@ ML2 Vision API DTO (Request/Response 스키마)
 
 위치: backend/app/dtos/ai_vision.py
 역할: 식단 분석 / 운동 캡처 인증 엔드포인트의 입출력 형식 정의
+
+요청 방식: multipart/form-data (UploadFile + Form)
+- 요청 DTO는 라우터에서 File()/Form() 파라미터로 직접 처리
+- 응답 DTO만 Pydantic BaseModel 사용
 """
 
+from typing import Any
+
 from pydantic import BaseModel, Field
-from typing import Optional, Any
-
 
 # ══════════════════════════════════════════════
-# 공통 응답
+# 응답 DTO
 # ══════════════════════════════════════════════
+
 
 class TaskResponse(BaseModel):
     """Celery 태스크 접수 응답"""
+
     task_id: str = Field(..., description="Celery 태스크 ID (결과 조회용)")
     status: str = Field(default="PENDING", description="태스크 상태")
     message: str = Field(..., description="안내 메시지")
@@ -22,42 +28,14 @@ class TaskResponse(BaseModel):
 
 class TaskResultResponse(BaseModel):
     """Celery 태스크 결과 조회 응답"""
+
     task_id: str
     status: str = Field(..., description="PENDING | SUCCESS | FAILURE")
-    result: Optional[Any] = Field(default=None, description="태스크 결과 (완료 시)")
-    error: Optional[str] = Field(default=None, description="에러 메시지 (실패 시)")
+    result: Any | None = Field(default=None, description="태스크 결과 (완료 시)")
+    error: str | None = Field(default=None, description="에러 메시지 (실패 시)")
 
 
 class ErrorResponse(BaseModel):
     """에러 응답"""
+
     detail: str
-
-
-# ══════════════════════════════════════════════
-# 식단 분석 요청
-# ══════════════════════════════════════════════
-
-class MealAnalyzeRequest(BaseModel):
-    """식단 분석 요청 (무료/유료 공용)"""
-    image_base64: str = Field(..., description="이미지 base64 인코딩 문자열")
-    media_type: str = Field(
-        default="image/jpeg",
-        description="이미지 MIME 타입 (image/jpeg, image/png, image/webp, image/gif)",
-    )
-    risk_factors: str = Field(
-        default="",
-        description="사용자 위험 요인 (예: '고혈압, 당뇨')",
-    )
-
-
-# ══════════════════════════════════════════════
-# 운동 캡처 인증 요청
-# ══════════════════════════════════════════════
-
-class ExerciseAnalyzeRequest(BaseModel):
-    """운동 앱 스크린샷 인증 요청"""
-    image_base64: str = Field(..., description="운동 앱 스크린샷 base64 인코딩 문자열")
-    media_type: str = Field(
-        default="image/jpeg",
-        description="이미지 MIME 타입",
-    )

--- a/backend/app/dtos/analysis.py
+++ b/backend/app/dtos/analysis.py
@@ -1,6 +1,7 @@
+from datetime import date
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 # ──────────────────────────────────────────────
 # Request DTOs
@@ -10,7 +11,10 @@ from pydantic import BaseModel, Field
 class GuestAnalysisRequest(BaseModel):
     """비회원 AI 건강 분석 요청 (DB 기록 없이 직접 수치 입력)"""
 
-    age: Annotated[int, Field(ge=1, le=120, description="나이 (만 나이)")]
+    birth_date: Annotated[
+        date,
+        Field(description="생년월일 (YYYY-MM-DD). 만 나이는 자동 계산됨."),
+    ]
     gender: Annotated[Literal["M", "F"], Field(description="성별 (M: 남성, F: 여성)")]
     height: Annotated[float, Field(ge=100, le=300, description="키 (cm)")]
     weight: Annotated[float, Field(ge=10, le=500, description="몸무게 (kg)")]
@@ -21,6 +25,33 @@ class GuestAnalysisRequest(BaseModel):
     smoke_yn: Annotated[bool, Field(description="흡연 여부")]
     alcohol_yn: Annotated[bool, Field(description="음주 여부")]
     exercise_yn: Annotated[bool, Field(description="규칙적 운동 여부")]
+
+    @computed_field
+    @property
+    def age(self) -> int:
+        """생년월일 기반 만 나이 자동 계산 (요청 시점 기준)"""
+        today = date.today()
+        age = today.year - self.birth_date.year
+        # 올해 생일이 아직 지나지 않았으면 1 감산
+        if (today.month, today.day) < (self.birth_date.month, self.birth_date.day):
+            age -= 1
+        return age
+
+    @model_validator(mode="after")
+    def validate_birth_date(self) -> "GuestAnalysisRequest":
+        """생년월일 유효성 검증 (미래 날짜 / 나이 범위 초과 차단)"""
+        today = date.today()
+
+        if self.birth_date > today:
+            raise ValueError("생년월일은 오늘 이후일 수 없습니다.")
+
+        if self.age < 1:
+            raise ValueError("나이는 최소 1세 이상이어야 합니다.")
+
+        if self.age > 120:
+            raise ValueError("유효하지 않은 생년월일입니다. (120세 초과)")
+
+        return self
 
 
 # ──────────────────────────────────────────────

--- a/backend/app/services/ai_vision_service.py
+++ b/backend/app/services/ai_vision_service.py
@@ -13,12 +13,22 @@ from celery.result import AsyncResult
 from app.core.config import Config
 
 # ──────────────────────────────────────────────
-# Celery 클라이언트 (backend → Redis → ai-worker 연결)
-# DB 0: Broker (task 대기열)
-# DB 1: Backend (task 완료 결과 저장)
+# Celery 클라이언트 역할별 분리
+#
+# send_task() 호출 시 Redis backend가 설정되어 있으면
+# Pub/Sub result consumer를 즉시 구독 시도 → 연결 실패 시 RuntimeError 발생
+#
+# 해결: 발송과 결과 조회를 별도 앱으로 분리
+#   - _celery_sender: broker만 설정 → Pub/Sub 구독 없음
+#   - _celery_result: broker + backend 설정 → AsyncResult 조회 전용
 # ──────────────────────────────────────────────
 _config = Config()
-celery_app = Celery(
+
+# 태스크 발송 전용 (Pub/Sub result consumer 미설정)
+_celery_sender = Celery(broker=_config.CELERY_BROKER_URL)
+
+# 결과 조회 전용 (backend 필요)
+_celery_result = Celery(
     broker=_config.CELERY_BROKER_URL,
     backend=_config.CELERY_BACKEND_URL,
 )
@@ -28,6 +38,7 @@ celery_app = Celery(
 # Service 클래스
 # ══════════════════════════════════════════════
 
+
 class AIVisionService:
     """ML2 Vision API Celery 태스크 호출 서비스"""
 
@@ -36,7 +47,7 @@ class AIVisionService:
     @staticmethod
     def enqueue_meal_free(image_base64: str, media_type: str, risk_factors: str = "") -> str:
         """식단 무료 분석 태스크를 큐에 등록하고 task_id를 반환한다."""
-        task = celery_app.send_task(
+        task = _celery_sender.send_task(
             "vision.analyze_meal_free",
             args=[image_base64, media_type, risk_factors],
         )
@@ -47,7 +58,7 @@ class AIVisionService:
     @staticmethod
     def enqueue_meal_paid(image_base64: str, media_type: str, risk_factors: str = "") -> str:
         """식단 유료 상세 리포트 태스크를 큐에 등록하고 task_id를 반환한다."""
-        task = celery_app.send_task(
+        task = _celery_sender.send_task(
             "vision.analyze_meal_paid",
             args=[image_base64, media_type, risk_factors],
         )
@@ -58,7 +69,7 @@ class AIVisionService:
     @staticmethod
     def enqueue_exercise(image_base64: str, media_type: str) -> str:
         """운동 캡처 인증 태스크를 큐에 등록하고 task_id를 반환한다."""
-        task = celery_app.send_task(
+        task = _celery_sender.send_task(
             "vision.analyze_exercise",
             args=[image_base64, media_type],
         )
@@ -69,7 +80,7 @@ class AIVisionService:
     @staticmethod
     def get_task_result(task_id: str) -> dict:
         """Celery 태스크 상태 및 결과를 조회한다."""
-        result = AsyncResult(task_id, app=celery_app)
+        result = AsyncResult(task_id, app=_celery_result)
 
         if result.state == "PENDING":
             return {"task_id": task_id, "status": "PENDING", "result": None, "error": None}

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -24,10 +24,24 @@ from app.repositories.health_repository import HealthRecordRepository
 
 logger = logging.getLogger(__name__)
 
-# Backend에서 Celery task를 이름 기반으로 호출 (AI 의존성 불필요)
+# ──────────────────────────────────────────────
+# Celery 클라이언트 역할별 분리
+#
+# send_task() 호출 시 Redis backend가 설정되어 있으면
+# Pub/Sub result consumer를 즉시 구독 시도 → 연결 실패 시 RuntimeError 발생
+#
+# 해결: 발송과 결과 조회를 별도 앱으로 분리
+#   - _celery_sender: broker만 설정 → Pub/Sub 구독 없음
+#   - _celery_result: broker + backend 설정 → AsyncResult 조회 전용
+# ──────────────────────────────────────────────
 config = Config()
-celery_app = Celery(
-    broker=config.CELERY_BROKER_URL,  # DB 0: task 대기열
+
+# 태스크 발송 전용 (Pub/Sub result consumer 미설정)
+_celery_sender = Celery(broker=config.CELERY_BROKER_URL)
+
+# 결과 조회 전용 (backend 필요)
+_celery_result = Celery(
+    broker=config.CELERY_BROKER_URL,
     backend=config.CELERY_BACKEND_URL,  # DB 1: task 완료 결과 저장
 )
 
@@ -79,7 +93,7 @@ class HealthAnalysisService:
             )
 
         # 4. Celery task 제출 (이름 기반 호출, AI 모듈 import 불필요)
-        task = celery_app.send_task(
+        task = _celery_sender.send_task(
             "ml1.analyze_health",
             args=[user_data, nickname, challenge_days],
         )
@@ -120,7 +134,7 @@ class HealthAnalysisService:
             return AnalysisResultResponse(status="success", data=json.loads(cached))
 
         # 3. Celery task 제출 (이름 기반 호출, AI 모듈 import 불필요)
-        task = celery_app.send_task(
+        task = _celery_sender.send_task(
             "ml1.analyze_health",
             args=[user_data, nickname, challenge_days],
         )
@@ -135,7 +149,7 @@ class HealthAnalysisService:
         - SUCCESS: 완료, 결과 반환
         - FAILURE: 실패, 에러 메시지 반환
         """
-        result = AsyncResult(task_id, app=celery_app)
+        result = AsyncResult(task_id, app=_celery_result)
 
         if result.state == "PENDING":
             return AnalysisResultResponse(status="pending")

--- a/backend/app/utils/jwt/tokens.py
+++ b/backend/app/utils/jwt/tokens.py
@@ -78,7 +78,7 @@ class Token:
     @classmethod
     def for_user(cls, user: User) -> Self:
         token = cls()
-        token["user_id"] = user.id
+        token["id"] = user.id
         return token
 
 

--- a/backend/app/utils/pubsub.py
+++ b/backend/app/utils/pubsub.py
@@ -1,0 +1,112 @@
+"""
+Redis Pub/Sub 롱 폴링 유틸리티
+
+역할: AI Worker가 발행한 태스크 완료 결과를 롱 폴링 방식으로 반환
+채널 형식: task:result:{task_id}
+DB: Redis DB 3 (Pub/Sub 전용)
+
+흐름:
+  [클라이언트] GET /tasks/{task_id}/wait 요청
+      → [FastAPI] Redis Pub/Sub 채널 구독 후 대기
+      → [AI Worker] 태스크 완료 → PUBLISH task:result:{task_id} {...}
+      → [FastAPI] 메시지 수신 → 즉시 JSON 응답 반환 → 연결 종료
+      → [클라이언트] 결과 수신 완료 (1회 요청으로 끝)
+
+타임아웃 처리:
+  - asyncio.timeout()으로 강제 타임아웃 적용 (기본 30초)
+  - 메시지가 없어도 시간 초과 시 확실히 반환됨
+  - 클라이언트는 pending 수신 시 즉시 재요청
+
+Note:
+  Redis Pub/Sub 채널은 DB 번호와 무관하게 서버 전역으로 공유된다.
+  DB 3 연결은 논리적 분리를 위한 구성이다.
+"""
+
+import asyncio
+import json
+import logging
+
+import redis.asyncio as aioredis
+
+from app.core.config import Config
+
+logger = logging.getLogger(__name__)
+
+_config = Config()
+
+# 롱 폴링 최대 대기 시간 (AI 분석 평균 처리 시간 고려)
+LONG_POLL_TIMEOUT_SECONDS = 30
+
+# 채널 접두어
+CHANNEL_PREFIX = "task:result"
+
+
+def build_channel(task_id: str) -> str:
+    """태스크 ID에 해당하는 Pub/Sub 채널 이름을 반환한다."""
+    return f"{CHANNEL_PREFIX}:{task_id}"
+
+
+async def _listen_once(pubsub: aioredis.client.PubSub) -> dict:
+    """
+    Pub/Sub 채널에서 실제 데이터 메시지 1건을 수신할 때까지 대기한다.
+
+    subscribe 확인 메시지는 무시하고, type="message"인 첫 번째 메시지를 반환한다.
+    외부에서 asyncio.timeout()으로 감싸서 타임아웃을 제어해야 한다.
+    """
+    async for message in pubsub.listen():
+        if message["type"] == "message":
+            return json.loads(message["data"])
+    return {}
+
+
+async def wait_task_result(task_id: str, timeout: int = LONG_POLL_TIMEOUT_SECONDS) -> dict | None:
+    """
+    Redis Pub/Sub 채널을 구독하여 태스크 완료 결과를 최대 timeout초 대기 후 반환한다.
+
+    롱 폴링 방식:
+      - 서버가 결과가 올 때까지 응답을 보류 (최대 timeout초)
+      - 결과 도착 즉시 반환 → HTTP 연결 종료
+      - 타임아웃 시 None 반환 → 라우터에서 pending 응답
+
+    타임아웃 처리:
+      asyncio.timeout()으로 강제 타임아웃 적용.
+      pubsub.listen()은 메시지 수신 시에만 제어가 반환되므로,
+      메시지 없이 시간이 초과되면 asyncio가 강제로 취소(CancelledError)하여
+      반드시 timeout초 이내에 함수가 종료된다.
+
+    Args:
+        task_id: Celery 태스크 ID
+        timeout: 최대 대기 시간 (초), 기본 30초
+
+    Returns:
+        dict: 태스크 결과 payload (완료 시)
+        None: 타임아웃 또는 오류 시
+    """
+    channel = build_channel(task_id)
+    redis_client = aioredis.from_url(_config.REDIS_PUBSUB_URL, decode_responses=True)
+    pubsub = redis_client.pubsub()
+
+    try:
+        await pubsub.subscribe(channel)
+        logger.info("롱 폴링 구독 시작 - channel: %s, timeout: %ds", channel, timeout)
+
+        # asyncio.timeout()으로 강제 타임아웃 적용
+        # pubsub.listen()이 무한 대기하더라도 timeout초 후 TimeoutError 발생
+        async with asyncio.timeout(timeout):
+            result = await _listen_once(pubsub)
+            logger.info("롱 폴링 결과 수신 - channel: %s", channel)
+            return result
+
+    except TimeoutError:
+        # asyncio.timeout() 초과 시 발생 (Python 3.11+)
+        logger.warning("롱 폴링 타임아웃 - channel: %s, %d초 초과", channel, timeout)
+        return None
+
+    except Exception as exc:
+        logger.error("롱 폴링 오류 - channel: %s, error: %s", channel, exc)
+        return None
+
+    finally:
+        await pubsub.unsubscribe(channel)
+        await redis_client.aclose()
+        logger.info("롱 폴링 구독 해제 - channel: %s", channel)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,10 @@ services:
         - linux/arm64
     image: ${DOCKER_USER}/${DOCKER_REPOSITORY}:ai-${AI_WORKER_VERSION}  # AI_WORKER_VERSION은 빌드된 이미지의 버전관리를 위함입니다. V1.0.0 형식으로 사용합니다.
     env_file: .env
-    command: uv run celery -A ai.celery_app worker --loglevel=info
+    # --pool=solo: fork 없이 단일 프로세스로 실행
+    # XGBoost, SHAP, numpy(OpenBLAS) 등 ML 라이브러리는 fork-safe하지 않아
+    # 기본 prefork 방식 사용 시 자식 프로세스에서 SIGSEGV(signal 11) 발생
+    command: uv run celery -A ai.celery_app worker --loglevel=info --pool=solo
     restart: always
     mem_limit: 4G
     networks:

--- a/nginx/prod_http.conf
+++ b/nginx/prod_http.conf
@@ -3,7 +3,7 @@ upstream fastapi {
 }
 
 server {
-    server_name 13.125.247.40;
+    server_name 54.180.116.239;
 
     listen 80;
 


### PR DESCRIPTION
## 📌 작업 내용
- Redis Pub/Sub 기반 롱 폴링 결과 수신 구현
- 분석/비전 라우터에 롱 폴링 엔드포인트 추가
- ai-worker Celery pool을 solo로 변경
- JWT payload 키를 user_id에서 id로 통일 및 인증 예외 처리 보강
- Vision API 요청을 base64 JSON에서 multipart/form-data로 변경

## 🔄 변경 파일
- 

## ✅ 테스트
- [x] 배포 후 Swaager로 동작 테스트 완료

## 🔗 관련 평가 항목
- close #37 
