### PR TITLE
[AI] feat: ml1.recalculate_risk 챌린지 달성 후 재계산 태스크 추가

### DIFF
--- a/ai/workers/predict.py
+++ b/ai/workers/predict.py
@@ -302,3 +302,30 @@ if __name__ == '__main__':
         print(f"{k}: {v}")
 
     print(f"\n위험도 변화: {result['risk_percent']} → {result2['risk_percent']}%")
+
+    # ── 챌린지 맞춤 추천 함수
+RISK_FACTOR_MAP = {
+    '고혈압': '고혈압',
+    '고령+고혈압': '고혈압',
+    '고콜레스테롤': '고콜레스테롤',
+    '고령+고콜레스테롤': '고콜레스테롤',
+    '고혈당': '고혈당',
+    '비만+고혈압': '과체중',
+    '고령·과체중': '과체중',
+    '흡연': '흡연자',
+    '흡연+음주': '음주자',
+    '운동부족': '과체중',
+}
+
+def recommend_challenges(top_risk_factors: list) -> list:
+    """
+    top_risk_factors 기반으로 챌린지 추천
+    Returns: 매칭된 target_risk_factors 목록
+    """
+    targets = set()
+    for factor in top_risk_factors:
+        mapped = RISK_FACTOR_MAP.get(factor)
+        if mapped:
+            targets.add(mapped)
+    targets.add('공통')  # 항상 공통 챌린지 포함
+    return list(targets)

--- a/ai/workers/tasks.py
+++ b/ai/workers/tasks.py
@@ -101,3 +101,44 @@ def analyze_health(self, user_data: dict, nickname: str = "사용자", challenge
     except Exception as exc:
         logger.error("ML1 분석 실패 (retry 시도) - task_id: %s, error: %s", task_id, exc)
         raise self.retry(exc=exc) from exc
+    
+# ──────────────────────────────────────────────
+# ML1 챌린지 달성 후 재계산 Celery Task
+# ──────────────────────────────────────────────
+@celery_app.task(
+    name="ml1.recalculate_risk",
+    bind=True,
+    max_retries=2,
+    default_retry_delay=5,
+)
+def recalculate_health(self, user_data: dict, completed_challenges: list, nickname: str = "사용자") -> dict:
+    """
+    챌린지 달성 후 위험도 재계산
+
+    Args:
+        user_data: 사용자 건강 데이터
+        completed_challenges: ['smoke_7days', 'active_7days']
+        nickname: 사용자 닉네임
+    """
+    from ai.workers.predict import recalculate_risk
+
+    task_id = self.request.id
+    logger.info("ML1 재계산 시작 - task_id: %s", task_id)
+
+    try:
+        result = recalculate_risk(user_data, completed_challenges)
+
+        result_payload = {
+            "status": "success",
+            "task_id": task_id,
+            "data": result,
+            "error": None,
+        }
+
+        _publish_result(task_id, result_payload)
+        logger.info("ML1 재계산 완료 - task_id: %s", task_id)
+        return result_payload
+
+    except Exception as exc:
+        logger.error("ML1 재계산 실패 - task_id: %s, error: %s", task_id, exc)
+        raise self.retry(exc=exc) from exc


### PR DESCRIPTION
## 📌 작업 내용
- 챌린지 달성 후 위험도 재계산 Celery 태스크 추가
- `recalculate_risk()` 함수 Celery 태스크로 래핑
- 
## 🔄 태스크 정보
- 태스크 이름: `ml1.recalculate_risk`
- 입력: user_data, completed_challenges, nickname
- 출력: 재계산된 위험도 결과

## ✅체크리스트
- [x] recalculate_risk 태스크 추가
- [x] Pub/Sub 결과 발행 포함
- [ ] BE 챌린지 API 연동 테스트

## 🔗 사용 예시
```python
celery_app.send_task(
    "ml1.recalculate_risk",
    args=[user_data, ["smoke_7days", "active_7days"], "닉네임"]
)