### PR TITLE
[BE] feat: 챌린지 API 구현 (목록 조회, 참여, 포기, 인증)

### DIFF
--- a/backend/app/apis/v1/__init__.py
+++ b/backend/app/apis/v1/__init__.py
@@ -6,6 +6,7 @@ from app.apis.v1.health_routers import health_router
 from app.apis.v1.social_routers import social_router
 from app.apis.v1.user_routers import user_router
 from app.apis.v1.ai_vision_routers import ai_vision_router
+from app.apis.v1.challenge_routers import challenge_router, user_challenge_router
 
 v1_routers = APIRouter(prefix="/api/v1")
 v1_routers.include_router(analysis_router)
@@ -14,3 +15,5 @@ v1_routers.include_router(health_router)
 v1_routers.include_router(social_router)
 v1_routers.include_router(user_router)
 v1_routers.include_router(ai_vision_router)
+v1_routers.include_router(challenge_router)
+v1_routers.include_router(user_challenge_router)

--- a/backend/app/apis/v1/challenge_routers.py
+++ b/backend/app/apis/v1/challenge_routers.py
@@ -1,0 +1,197 @@
+"""
+챌린지 라우터 — 챌린지 조회 / 선택 / 포기 / 챌린지 인증
+
+위치: backend/app/apis/v1/challenge_routers.py
+역할: HTTP 요청 수신 → ChallengeService로 비즈니스 로직 위임 → 응답 반환
+
+패턴: auth_routers.py 패턴 준수
+  - APIRouter with prefix & tags
+  - JSONResponse 직접 반환
+  - Swagger 문서화 (summary, description, responses)
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from fastapi.responses import JSONResponse as Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.databases import get_db_session
+from app.dtos.challenge import (
+    ChallengeListResponse,
+    ChallengeLogRequest,
+    ChallengeLogResponse,
+    ChallengeResponse,
+    ErrorResponse,
+    MessageResponse,
+    UserChallengeResponse,
+)
+from app.services.challenge_service import ChallengeService
+
+# /api/v1/challenges 경로의 라우터
+challenge_router = APIRouter(prefix="/challenges", tags=["challenges"])
+
+# /api/v1/user-challenges 경로의 라우터
+user_challenge_router = APIRouter(prefix="/user-challenges", tags=["challenges"])
+
+
+# ══════════════════════════════════════════════
+# 1. 챌린지 목록 조회
+# ══════════════════════════════════════════════
+
+@challenge_router.get(
+    "",
+    response_model=ChallengeListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="챌린지 목록 조회",
+    description="전체 챌린지 풀 목록을 조회합니다. "
+                "프론트에서 카테고리별 탭 필터링에 사용됩니다.",
+    responses={
+        200: {"description": "챌린지 목록 조회 성공", "model": ChallengeListResponse},
+    },
+)
+async def get_challenges(
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = ChallengeService(session)
+    challenges = await service.get_all_challenges()
+
+    return Response(
+        content=ChallengeListResponse(
+            challenges=[
+                ChallengeResponse(
+                    id=c.id,
+                    category=c.category.value,
+                    title=c.title,
+                    description=c.description,
+                    expected_effect=c.expected_effect,
+                    verification_method=c.verification_method.value,
+                    target_risk_factors=c.target_risk_factors,
+                    duration_days=c.duration_days,
+                    required_success_days=c.required_success_days,
+                )
+                for c in challenges
+            ]
+        ).model_dump(),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+# ══════════════════════════════════════════════
+# 2. 챌린지 선택 (참여)
+# ══════════════════════════════════════════════
+
+@challenge_router.post(
+    "/{challenge_id}/join",
+    response_model=UserChallengeResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="챌린지 참여 (시작하기)",
+    description="챌린지를 선택하여 참여를 시작합니다. "
+                "user_challenges 테이블에 active 상태로 등록됩니다.",
+    responses={
+        201: {"description": "챌린지 참여 성공", "model": UserChallengeResponse},
+        404: {"description": "존재하지 않는 챌린지", "model": ErrorResponse},
+        409: {"description": "이미 참여 중인 챌린지", "model": ErrorResponse},
+    },
+)
+async def join_challenge(
+    challenge_id: int,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    user_id: int = Query(..., description="사용자 ID (추후 인증 미들웨어로 대체)"),
+) -> Response:
+    service = ChallengeService(session)
+    user_challenge = await service.join_challenge(
+        user_id=user_id,
+        challenge_id=challenge_id,
+    )
+
+    return Response(
+        content=UserChallengeResponse(
+            id=user_challenge.id,
+            user_id=user_challenge.user_id,
+            challenge_id=user_challenge.challenge_id,
+            status=user_challenge.status.value,
+            current_streak=user_challenge.current_streak,
+            start_date=user_challenge.start_date,
+            completed_at=user_challenge.completed_at,
+        ).model_dump(mode="json"),
+        status_code=status.HTTP_201_CREATED,
+    )
+
+
+# ══════════════════════════════════════════════
+# 3. 챌린지 포기
+# ══════════════════════════════════════════════
+
+@user_challenge_router.patch(
+    "/{user_challenge_id}/abandon",
+    response_model=MessageResponse,
+    status_code=status.HTTP_200_OK,
+    summary="챌린지 포기",
+    description="진행 중인 챌린지를 포기합니다. "
+                "status가 abandoned로 변경됩니다.",
+    responses={
+        200: {"description": "포기 처리 완료", "model": MessageResponse},
+        400: {"description": "이미 완료/포기된 챌린지", "model": ErrorResponse},
+        404: {"description": "존재하지 않는 참여 기록", "model": ErrorResponse},
+    },
+)
+async def abandon_challenge(
+    user_challenge_id: int,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = ChallengeService(session)
+    await service.abandon_challenge(user_challenge_id)
+
+    return Response(
+        content=MessageResponse(
+            message="챌린지를 포기했습니다.",
+        ).model_dump(),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+# ══════════════════════════════════════════════
+# 4. 챌린지 인증
+# ══════════════════════════════════════════════
+
+@user_challenge_router.post(
+    "/{user_challenge_id}/log",
+    response_model=ChallengeLogResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="챌린지 인증",
+    description="오늘의 챌린지 수행을 인증합니다. "
+                "하루 1회만 가능하며, streak이 자동으로 업데이트됩니다. "
+                "챌린지 성공/실패는 종료일 기준으로 최종 판정됩니다.",
+    responses={
+        201: {"description": "인증 성공", "model": ChallengeLogResponse},
+        400: {"description": "이미 완료/포기된 챌린지", "model": ErrorResponse},
+        404: {"description": "존재하지 않는 참여 기록", "model": ErrorResponse},
+        409: {"description": "오늘 이미 인증 완료", "model": ErrorResponse},
+    },
+)
+async def log_daily(
+    user_challenge_id: int,
+    request: ChallengeLogRequest,
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = ChallengeService(session)
+    log = await service.log_daily(
+        user_challenge_id=user_challenge_id,
+        verification_type=request.verification_type,
+        input_value=request.input_value,
+        cv_result_id=request.cv_result_id,
+    )
+
+    return Response(
+        content=ChallengeLogResponse(
+            id=log.id,
+            user_challenge_id=log.user_challenge_id,
+            log_date=log.log_date,
+            verification_type=log.verification_type.value,
+            input_value=log.input_value,
+            cv_result_id=log.cv_result_id,
+            created_at=log.created_at,
+        ).model_dump(mode="json"),
+        status_code=status.HTTP_201_CREATED,
+    )

--- a/backend/app/dtos/challenge.py
+++ b/backend/app/dtos/challenge.py
@@ -1,0 +1,96 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.models.challenges import VerificationMethodEnum
+
+
+# ──────────────────────────────────────────────
+# Request DTOs
+# ──────────────────────────────────────────────
+
+class ChallengeLogRequest(BaseModel):
+    """챌린지 인증 요청"""
+    verification_type: VerificationMethodEnum = Field(
+        ...,
+        description="인증 방식: checklist / input / cv",
+        examples=["checklist"],
+    )
+    input_value: str | None = Field(
+        default=None,
+        description="수치 입력값 (input 방식일 때만 사용, 예: 흡연 개피수)",
+        examples=["3"],
+    )
+    cv_result_id: int | None = Field(
+        default=None,
+        description="CV 분석 결과 ID (cv 방식일 때만 사용)",
+    )
+
+    @model_validator(mode="after")
+    def check_required_fields(self):
+        if self.verification_type == VerificationMethodEnum.INPUT and self.input_value is None:
+            raise ValueError("input 방식은 input_value가 필요합니다.")
+        if self.verification_type == VerificationMethodEnum.CV and self.cv_result_id is None:
+            raise ValueError("cv 방식은 cv_result_id가 필요합니다.")
+        if self.verification_type == VerificationMethodEnum.CHECKLIST:
+            if self.input_value is not None or self.cv_result_id is not None:
+                raise ValueError("checklist 방식은 input_value, cv_result_id를 사용하지 않습니다.")
+        return self
+
+
+# ──────────────────────────────────────────────
+# Response DTOs
+# ──────────────────────────────────────────────
+
+class ChallengeResponse(BaseModel):
+    """챌린지 풀 단건 응답"""
+    id: int
+    category: str
+    title: str
+    description: str | None = None
+    expected_effect: str | None = None
+    verification_method: str
+    target_risk_factors: str | None = None
+    duration_days: int
+    required_success_days: int
+
+
+class ChallengeListResponse(BaseModel):
+    """챌린지 목록 응답"""
+    challenges: list[ChallengeResponse]
+
+
+class UserChallengeResponse(BaseModel):
+    """사용자 챌린지 참여 응답"""
+    id: int
+    user_id: int
+    challenge_id: int
+    status: str
+    current_streak: int
+    start_date: date
+    completed_at: datetime | None = None
+
+
+class ChallengeLogResponse(BaseModel):
+    """챌린지 인증 응답"""
+    id: int
+    user_challenge_id: int
+    log_date: date
+    verification_type: str
+    input_value: str | None = None
+    cv_result_id: int | None = None
+    created_at: datetime
+
+
+class MessageResponse(BaseModel):
+    """단순 메시지 응답 (포기 등)"""
+    message: str
+
+
+# ──────────────────────────────────────────────
+# Error Response DTOs (Swagger 문서 표시용)
+# ──────────────────────────────────────────────
+
+class ErrorResponse(BaseModel):
+    """에러 응답 공통 형식"""
+    detail: str

--- a/backend/app/models/challenges.py
+++ b/backend/app/models/challenges.py
@@ -24,6 +24,7 @@ class UserChallengeStatusEnum(str, enum.Enum):
     ACTIVE = "active"
     COMPLETED = "completed"
     ABANDONED = "abandoned"
+    FAILED = "failed" 
 
 
 # 챌린지 마스터 테이블

--- a/backend/app/repositories/challenge_repository.py
+++ b/backend/app/repositories/challenge_repository.py
@@ -1,0 +1,144 @@
+"""
+챌린지 레포지토리 — DB 쿼리 모음
+
+위치: backend/app/repositories/challenge_repository.py
+역할: challenges, user_challenges, challenge_logs 테이블의 CRUD 쿼리
+"""
+
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.challenges import (
+    Challenge,
+    ChallengeLog,
+    UserChallenge,
+    UserChallengeStatusEnum,
+    VerificationMethodEnum,
+)
+
+
+class ChallengeRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    # ══════════════════════════════════════════
+    # challenges (챌린지 풀)
+    # ══════════════════════════════════════════
+
+    async def get_all_challenges(self) -> list[Challenge]:
+        """전체 챌린지 목록 조회"""
+        result = await self.session.execute(
+            select(Challenge)
+        )
+        return list(result.scalars().all())
+
+    async def get_challenge_by_id(self, challenge_id: int) -> Challenge | None:
+        """챌린지 단건 조회 (존재 여부 확인용)"""
+        result = await self.session.execute(
+            select(Challenge).where(Challenge.id == challenge_id)
+        )
+        return result.scalar_one_or_none()
+
+    # ══════════════════════════════════════════
+    # user_challenges (참여 관리)
+    # ══════════════════════════════════════════
+
+    async def get_user_challenge_by_id(self, user_challenge_id: int) -> UserChallenge | None:
+        """사용자 챌린지 단건 조회"""
+        result = await self.session.execute(
+            select(UserChallenge).where(UserChallenge.id == user_challenge_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active_user_challenge(
+        self, user_id: int, challenge_id: int
+    ) -> UserChallenge | None:
+        """해당 유저가 이 챌린지에 이미 active로 참여 중인지 확인 (중복 참여 방지)"""
+        result = await self.session.execute(
+            select(UserChallenge).where(
+                UserChallenge.user_id == user_id,
+                UserChallenge.challenge_id == challenge_id,
+                UserChallenge.status == UserChallengeStatusEnum.ACTIVE,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_user_challenge(
+        self, user_id: int, challenge_id: int, start_date: date
+    ) -> UserChallenge:
+        """챌린지 참여 등록 (user_challenges INSERT)"""
+        user_challenge = UserChallenge(
+            user_id=user_id,
+            challenge_id=challenge_id,
+            status=UserChallengeStatusEnum.ACTIVE,
+            current_streak=0,
+            start_date=start_date,
+        )
+        self.session.add(user_challenge)
+        await self.session.commit()
+        await self.session.refresh(user_challenge)
+        return user_challenge
+
+    async def update_status(
+        self, user_challenge: UserChallenge, new_status: UserChallengeStatusEnum
+    ) -> UserChallenge:
+        """챌린지 상태 변경 (active → abandoned / completed)"""
+        user_challenge.status = new_status
+        await self.session.commit()
+        await self.session.refresh(user_challenge)
+        return user_challenge
+
+    async def update_streak(
+        self, user_challenge: UserChallenge, new_streak: int
+    ) -> None:
+        """연속 달성 일수 업데이트"""
+        user_challenge.current_streak = new_streak
+        await self.session.commit()
+
+    # ══════════════════════════════════════════
+    # challenge_logs (인증 기록)
+    # ══════════════════════════════════════════
+
+    async def get_log_by_date(
+        self, user_challenge_id: int, log_date: date
+    ) -> ChallengeLog | None:
+        """해당 날짜에 이미 인증했는지 확인 (하루 1회 제한)"""
+        result = await self.session.execute(
+            select(ChallengeLog).where(
+                ChallengeLog.user_challenge_id == user_challenge_id,
+                ChallengeLog.log_date == log_date,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_log(
+        self,
+        user_challenge_id: int,
+        log_date: date,
+        verification_type: VerificationMethodEnum,
+        input_value: str | None = None,
+        cv_result_id: int | None = None,
+    ) -> ChallengeLog:
+        """인증 기록 생성 (challenge_logs INSERT)"""
+        log = ChallengeLog(
+            user_challenge_id=user_challenge_id,
+            log_date=log_date,
+            verification_type=verification_type,
+            input_value=input_value,
+            cv_result_id=cv_result_id,
+        )
+        self.session.add(log)
+        await self.session.commit()
+        await self.session.refresh(log)
+        return log
+
+    async def count_logs(self, user_challenge_id: int) -> int:
+        """해당 챌린지의 총 인증 횟수 조회 (완료 판정용)"""
+        result = await self.session.execute(
+            select(func.count()).where(
+                ChallengeLog.user_challenge_id == user_challenge_id
+            )
+        )
+        return result.scalar() or 0

--- a/backend/app/services/challenge_service.py
+++ b/backend/app/services/challenge_service.py
@@ -1,0 +1,216 @@
+"""
+챌린지 서비스 — 비즈니스 로직
+
+위치: backend/app/services/challenge_service.py
+역할: 검증(중복 참여, 하루 1회, 상태 확인) + 레포지토리 호출
+
+패턴: auth.py 서비스 패턴 준수
+  - __init__(self, session) → 레포지토리 주입
+  - HTTPException으로 에러 반환
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette import status
+
+from app.models.challenges import (
+    UserChallenge,
+    UserChallengeStatusEnum,
+    VerificationMethodEnum,
+)
+from app.repositories.challenge_repository import ChallengeRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ChallengeService:
+    def __init__(self, session: AsyncSession):
+        self.repo = ChallengeRepository(session)
+
+    # ══════════════════════════════════════════
+    # 1. 챌린지 목록 조회
+    # ══════════════════════════════════════════
+
+    async def get_all_challenges(self):
+        """전체 챌린지 풀 조회"""
+        logger.info("전체 챌린지 목록 조회")
+        return await self.repo.get_all_challenges()
+
+    # ══════════════════════════════════════════
+    # 2. 챌린지 선택 (참여)
+    # ══════════════════════════════════════════
+
+    async def join_challenge(self, user_id: int, challenge_id: int) -> UserChallenge:
+        """
+        챌린지 참여 등록
+        검증:
+          - 챌린지 존재 여부 (404)
+          - 중복 참여 방지: 같은 챌린지에 active 상태가 이미 있으면 차단 (409)
+        """
+        logger.info("챌린지 참여 요청 - user_id: %d, challenge_id: %d", user_id, challenge_id)
+
+        # 챌린지 존재 여부 확인
+        challenge = await self.repo.get_challenge_by_id(challenge_id)
+        if not challenge:
+            logger.warning("존재하지 않는 챌린지 - challenge_id: %d", challenge_id)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"챌린지를 찾을 수 없습니다. (id: {challenge_id})",
+            )
+
+        # 중복 참여 방지
+        existing = await self.repo.get_active_user_challenge(user_id, challenge_id)
+        if existing:
+            logger.warning(
+                "이미 참여 중인 챌린지 - user_id: %d, challenge_id: %d",
+                user_id, challenge_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="이미 참여 중인 챌린지입니다.",
+            )
+
+        user_challenge = await self.repo.create_user_challenge(
+            user_id=user_id,
+            challenge_id=challenge_id,
+            start_date=date.today(),
+        )
+        logger.info(
+            "챌린지 참여 완료 - user_challenge_id: %d", user_challenge.id
+        )
+        return user_challenge
+
+    # ══════════════════════════════════════════
+    # 3. 챌린지 포기
+    # ══════════════════════════════════════════
+
+    async def abandon_challenge(self, user_challenge_id: int) -> UserChallenge:
+        """
+        챌린지 포기 처리
+        검증:
+          - user_challenge 존재 여부 (404)
+          - active 상태만 포기 가능 (400)
+        """
+        logger.info("챌린지 포기 요청 - user_challenge_id: %d", user_challenge_id)
+
+        user_challenge = await self._get_active_user_challenge(user_challenge_id)
+
+        updated = await self.repo.update_status(
+            user_challenge, UserChallengeStatusEnum.ABANDONED
+        )
+        logger.info("챌린지 포기 완료 - user_challenge_id: %d", user_challenge_id)
+        return updated
+
+    # ══════════════════════════════════════════
+    # 4. 챌린지 인증
+    # ══════════════════════════════════════════
+
+    async def log_daily(
+        self,
+        user_challenge_id: int,
+        verification_type: VerificationMethodEnum,
+        input_value: str | None = None,
+        cv_result_id: int | None = None,
+    ):
+        """
+        챌린지 인증 기록
+        검증:
+          - user_challenge 존재 여부 (404)
+          - active 상태만 인증 가능 (400)
+          - 하루 1회 인증 제한 (409)
+        처리:
+          - challenge_logs에 기록 생성
+          - current_streak 업데이트
+          - 챌린지 기간 종료 시(마지막 날 포함) 최종 판정
+        """
+        logger.info("챌린지 인증 요청 - user_challenge_id: %d", user_challenge_id)
+
+        user_challenge = await self._get_active_user_challenge(user_challenge_id)
+
+        # 하루 1회 인증 제한
+        today = date.today()
+        existing_log = await self.repo.get_log_by_date(user_challenge_id, today)
+        if existing_log:
+            logger.warning(
+                "오늘 이미 인증 완료 - user_challenge_id: %d", user_challenge_id
+            )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="오늘은 이미 인증을 완료했습니다.",
+            )
+
+        # 인증 기록 생성
+        log = await self.repo.create_log(
+            user_challenge_id=user_challenge_id,
+            log_date=today,
+            verification_type=verification_type,
+            input_value=input_value,
+            cv_result_id=cv_result_id,
+        )
+
+        # streak 업데이트
+        new_streak = user_challenge.current_streak + 1
+        await self.repo.update_streak(user_challenge, new_streak)
+
+        # 챌린지 기간 종료 시 최종 판정 (마지막 날 인증 후 판정 포함)
+        challenge = await self.repo.get_challenge_by_id(user_challenge.challenge_id)
+        if challenge:
+            end_date = user_challenge.start_date + timedelta(days=challenge.duration_days - 1)
+            today = date.today()
+
+            if today >= end_date:
+                total_logs = await self.repo.count_logs(user_challenge_id)
+
+                if total_logs >= challenge.required_success_days:
+                    user_challenge.completed_at = datetime.now()
+                    await self.repo.update_status(
+                        user_challenge, UserChallengeStatusEnum.COMPLETED
+                    )
+                    logger.info(
+                        "챌린지 성공! - user_challenge_id: %d, total_logs: %d/%d",
+                        user_challenge_id, total_logs, challenge.required_success_days,
+                    )
+                else:
+                    await self.repo.update_status(
+                        user_challenge, UserChallengeStatusEnum.FAILED
+                    )
+                    logger.info(
+                        "챌린지 실패 - user_challenge_id: %d, total_logs: %d/%d",
+                        user_challenge_id, total_logs, challenge.required_success_days,
+                    )
+
+        logger.info(
+            "인증 완료 - user_challenge_id: %d, streak: %d",
+            user_challenge_id, new_streak,
+        )
+        return log
+
+    # ══════════════════════════════════════════
+    # 공통 헬퍼
+    # ══════════════════════════════════════════
+
+    async def _get_active_user_challenge(
+        self, user_challenge_id: int
+    ) -> UserChallenge:
+        """
+        user_challenge 조회 + active 상태 검증
+        포기, 챌린지 인증에서 공통으로 사용
+        """
+        user_challenge = await self.repo.get_user_challenge_by_id(user_challenge_id)
+
+        if not user_challenge:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"참여 중인 챌린지를 찾을 수 없습니다. (id: {user_challenge_id})",
+            )
+
+        if user_challenge.status != UserChallengeStatusEnum.ACTIVE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"이미 {user_challenge.status.value} 상태인 챌린지입니다.",
+            )
+
+        return user_challenge


### PR DESCRIPTION
## 📌 작업 내용
- 챌린지 목록 조회 (`GET /challenges`)
- 챌린지 참여 (`POST /challenges/{id}/join`)
- 챌린지 포기 (`PATCH /user-challenges/{id}/abandon`)
- 챌린지 인증 (`POST /user-challenges/{id}/log`)
- router / service / repository / DTO 
- 챌린지 성공/실패는 종료일 기준 최종 판정

## 🔄 변경 파일
- `app/apis/v1/challenge_routers.py` (신규)
- `app/dtos/challenge.py` (신규)
- `app/services/challenge_service.py` (신규)
- `app/repositories/challenge_repository.py` (신규)
- `app/apis/v1/__init__.py` (라우터 등록)
- `app/models/challenges.py` (FAILED enum 추가)

## ✅ 테스트


## 🔗 관련 평가 항목
- 

## 📝 리뷰어에게
- 

## 📸 스크린샷 (선택)
