### PR TITLE
[BE] feat: Duck DNS 도메인 연결 및 SSL(HTTPS) 인증서 적용

### DIFF
--- a/nginx/prod_https.conf
+++ b/nginx/prod_https.conf
@@ -5,7 +5,7 @@ upstream fastapi {
 # http
 server {
     listen 80;
-    server_name 도메인;
+    server_name myhealthbuddy.duckdns.org;
 
     # 추후 certbot ssl 인증서 갱신 시 필요
     location /.well-known/acme-challenge/ {
@@ -23,12 +23,12 @@ server {
 
 # https
 server {
-    server_name 도메인;
+    server_name myhealthbuddy.duckdns.org;
 
     listen 443 ssl;
 
-    ssl_certificate /etc/letsencrypt/live/도메인/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/도메인/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/myhealthbuddy.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/myhealthbuddy.duckdns.org/privkey.pem;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;


### PR DESCRIPTION
## 📌 작업 내용
- https 반영을 위한 SSL 발급
- Duck DNS로 도메인 발급

## 🔄 변경 파일
- 

## ✅ 테스트
- [x] 주소 연동 확인 완료 https://myhealthbuddy.duckdns.org/api/docs

## 🔗 관련 평가 항목
- Close #45 

## 📝 리뷰어에게
- 

## 📸 스크린샷 (선택)
