### PR TITLE
[BE] feat: ML1 예측 결과 DB 저장 및 조회 API 구현

### DIFF
--- a/ai/workers/worker.py
+++ b/ai/workers/worker.py
@@ -3,10 +3,10 @@ AI Worker 통합 모듈
 ML1: XGBoost 위험도 예측 + ChatGPT 건강 코멘트 생성
 """
 
+import asyncio
 import json
 import logging
 import os
-import asyncio
 
 from openai import OpenAI
 
@@ -26,15 +26,74 @@ def ml1_predict(user_data: dict) -> dict:
 
 # ── ML1 LLM 코멘트 함수
 def ml1_comment(user_info: dict) -> dict:
-    from langfuse import Langfuse
-    from langfuse.openai import openai as langfuse_openai
+    """
+    위험도 결과 → 건강 코멘트 생성.
+    Celery prefork 환경에서 fork-safety 문제 방지를 위해
+    OpenAI 클라이언트를 함수 내부에서 생성.
 
-    langfuse = Langfuse(
-        public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
-        secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
-        host=os.getenv("LANGFUSE_HOST", "http://localhost:3000")
+    Langfuse 로깅:
+    - LANGFUSE_PUBLIC_KEY가 설정된 경우(로컬 Docker)에만 활성화
+    - EC2 등 Langfuse 미설치 환경에서는 기본 OpenAI 클라이언트로 폴백
+    """
+    # fork된 워커 프로세스마다 독립적인 클라이언트 인스턴스 생성
+    # Langfuse 설정 여부에 따라 클라이언트 선택
+    langfuse_public_key = os.getenv("LANGFUSE_PUBLIC_KEY")
+    if langfuse_public_key:
+        logger.info("Langfuse 설정")
+        try:
+            from langfuse import Langfuse
+            from langfuse.openai import openai as langfuse_openai
+
+            # LANGFUSE_HOST 또는 LANGFUSE_BASE_URL 둘 다 지원
+            langfuse_host = os.getenv("LANGFUSE_HOST") or os.getenv("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
+            langfuse = Langfuse(
+                public_key=langfuse_public_key,
+                secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+                host=langfuse_host,
+            )
+            client = langfuse_openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"), timeout=60)
+            use_langfuse = True
+            logger.info("Langfuse 클라이언트 초기화 완료 - host: %s", langfuse_host)
+        except Exception as e:
+            logger.warning("Langfuse 초기화 실패, 기본 OpenAI 클라이언트로 폴백 - %s", e)
+            client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            use_langfuse = False
+            langfuse = None
+    else:
+        logger.info("Langfuse 미설정, 기본 OpenAI 클라이언트 사용")
+        # Langfuse 미설정 환경 (EC2 등): 기본 OpenAI 클라이언트 사용
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        use_langfuse = False
+        langfuse = None
+
+    user_prompt = build_user_prompt(user_info)
+
+    logger.info("OpenAI API 호출 시작")
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0,
+        timeout=60,
     )
-    client = langfuse_openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"), timeout=60)
+    logger.info("OpenAI API 호출 완료")
+
+    raw = response.choices[0].message.content
+
+    if use_langfuse and langfuse:
+        langfuse.flush()
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {
+            "evaluation": "건강 데이터를 분석했습니다.",
+            "alert": None,
+            "missions": [],
+            "encouragement": "오늘도 건강한 하루 보내세요!",
+        }
 
 
 # ── ML1 통합 실행 함수

--- a/ai/workers/worker.py
+++ b/ai/workers/worker.py
@@ -41,30 +41,21 @@ def ml1_comment(user_info: dict) -> dict:
     if langfuse_public_key:
         logger.info("Langfuse 설정")
         try:
-            from langfuse import Langfuse
             from langfuse.openai import openai as langfuse_openai
 
-            # LANGFUSE_HOST 또는 LANGFUSE_BASE_URL 둘 다 지원
-            langfuse_host = os.getenv("LANGFUSE_HOST") or os.getenv("LANGFUSE_BASE_URL", "https://cloud.langfuse.com")
-            langfuse = Langfuse(
-                public_key=langfuse_public_key,
-                secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
-                host=langfuse_host,
-            )
+            # langfuse_openai가 환경변수(LANGFUSE_PUBLIC_KEY 등)를 자동으로 읽어 내부 클라이언트 구성
             client = langfuse_openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"), timeout=60)
             use_langfuse = True
-            logger.info("Langfuse 클라이언트 초기화 완료 - host: %s", langfuse_host)
+            logger.info("Langfuse 클라이언트 초기화 완료")
         except Exception as e:
             logger.warning("Langfuse 초기화 실패, 기본 OpenAI 클라이언트로 폴백 - %s", e)
             client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
             use_langfuse = False
-            langfuse = None
     else:
         logger.info("Langfuse 미설정, 기본 OpenAI 클라이언트 사용")
         # Langfuse 미설정 환경 (EC2 등): 기본 OpenAI 클라이언트 사용
         client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         use_langfuse = False
-        langfuse = None
 
     user_prompt = build_user_prompt(user_info)
 
@@ -82,8 +73,9 @@ def ml1_comment(user_info: dict) -> dict:
 
     raw = response.choices[0].message.content
 
-    if use_langfuse and langfuse:
-        langfuse.flush()
+    if use_langfuse:
+        # langfuse_openai 내부 클라이언트의 버퍼를 Cloud로 전송
+        langfuse_openai.flush()
 
     try:
         return json.loads(raw)

--- a/backend/app/apis/v1/analysis_routers.py
+++ b/backend/app/apis/v1/analysis_routers.py
@@ -8,13 +8,62 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.redis import get_redis
 from app.db.databases import get_db_session
 from app.dependencies.security import get_request_user
-from app.dtos.analysis import AnalysisResultResponse, AnalysisTaskResponse, GuestAnalysisRequest
+from app.dtos.analysis import (
+    AnalysisResultResponse,
+    AnalysisTaskResponse,
+    GuestAnalysisRequest,
+    PredictionResultListResponse,
+    PredictionResultResponse,
+)
 from app.models.users import User
 from app.services.analysis import HealthAnalysisService
 from app.utils.pubsub import wait_task_result
 
 # /api/v1/health/analysis 경로의 라우터. AI 건강 분석 API를 담당한다.
 analysis_router = APIRouter(prefix="/health/analysis", tags=["analysis"])
+
+
+@analysis_router.get(
+    "/history",
+    response_model=PredictionResultListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="내 예측 결과 목록 조회",
+    description="로그인한 사용자의 심혈관 위험도 예측 결과 목록을 최신순으로 반환한다. (최대 20건)",
+)
+async def get_prediction_history(
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
+) -> Response:
+    service = HealthAnalysisService(session, redis)
+    items = await service.get_prediction_history(user.id)
+    result = PredictionResultListResponse(
+        items=[PredictionResultResponse.model_validate(item) for item in items],
+        total=len(items),
+    )
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@analysis_router.get(
+    "/records/{record_id}/result",
+    response_model=PredictionResultListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="특정 건강검진의 예측 결과 목록 조회",
+    description="건강검진 기록 ID로 해당 기록에 대한 심혈관 위험도 예측 결과 목록을 반환한다.",
+)
+async def get_prediction_results_by_record(
+    record_id: int,
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
+) -> Response:
+    service = HealthAnalysisService(session, redis)
+    items = await service.get_prediction_result_by_record(record_id, user)
+    result = PredictionResultListResponse(
+        items=[PredictionResultResponse.model_validate(item) for item in items],
+        total=len(items),
+    )
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
 
 
 @analysis_router.post(
@@ -119,7 +168,13 @@ async def wait_analysis_result(
             status_code=status.HTTP_200_OK,
         )
 
-    # 3. 결과 도착 → 즉시 반환
+    # 3. 결과 도착 → Celery backend에서 재조회하여 DB 저장 후 반환
+    #    (Pub/Sub으로 받은 데이터와 동일하나, _persist_prediction_result 트리거 목적)
+    final_result = await service.get_analysis_result(task_id)
+    if final_result.status != "pending":
+        return Response(final_result.model_dump(), status_code=status.HTTP_200_OK)
+
+    # Celery backend 반영 지연 방어: Pub/Sub 데이터를 직접 반환
     return Response(
         AnalysisResultResponse(
             status=data.get("status", "failed"),

--- a/backend/app/apis/v1/user_routers.py
+++ b/backend/app/apis/v1/user_routers.py
@@ -11,6 +11,7 @@ from app.dtos.users import (
     InitialProfileRequest,
     ProfileUpdateRequest,
     UserInfoResponse,
+    WithdrawRequest,
     WithdrawResponse,
 )
 from app.models.users import User
@@ -74,14 +75,15 @@ async def update_profile(
     response_model=WithdrawResponse,
     status_code=status.HTTP_200_OK,
     summary="회원 탈퇴",
-    description="로그인한 사용자의 계정과 모든 관련 데이터를 영구적으로 삭제한다.",
+    description="로그인한 사용자의 계정을 탈퇴 처리한다. 탈퇴 사유는 선택 입력이며 최대 500자이다.",
 )
 async def withdraw_user(
-    user: Annotated[User, Depends(get_request_user)],  # 탈퇴할 사용자 본인 확인
+    data: WithdrawRequest,
+    user: Annotated[User, Depends(get_request_user)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> Response:
     service = UserManageService(session)
-    await service.withdraw_user(user)
+    await service.withdraw_user(user, reason=data.reason)
     return Response(
         WithdrawResponse(message="회원 탈퇴가 완료되었습니다.").model_dump(),
         status_code=status.HTTP_200_OK,

--- a/backend/app/dtos/analysis.py
+++ b/backend/app/dtos/analysis.py
@@ -1,7 +1,9 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, computed_field, model_validator
+
+from app.dtos.base import BaseSerializerModel
 
 # ──────────────────────────────────────────────
 # Request DTOs
@@ -72,3 +74,27 @@ class AnalysisResultResponse(BaseModel):
     status: str  # "pending" | "success" | "failed"
     data: dict | None = None  # {"ml1_predict": {...}, "ml1_comment": {...}}
     error: str | None = None
+
+
+class PredictionResultResponse(BaseSerializerModel):
+    """DB에 저장된 예측 결과 단건 응답"""
+
+    id: int
+    record_id: int
+    trigger_type: str
+    cvd_risk_percent: float
+    cvd_age: int
+    risk_level: str
+    top_risk_factors: list | None  # SHAP 기반 위험 요인 문자열 목록
+    ai_evaluation: str | None
+    ai_alert: str | None
+    ai_missions: list | None  # 챌린지 추천 목록 (각 항목: title, action, reason)
+    ai_encouragement: str | None
+    created_at: datetime
+
+
+class PredictionResultListResponse(BaseModel):
+    """예측 결과 목록 응답"""
+
+    items: list[PredictionResultResponse]
+    total: int

--- a/backend/app/dtos/users.py
+++ b/backend/app/dtos/users.py
@@ -49,5 +49,14 @@ class DashboardResponse(BaseSerializerModel):
     created_at: datetime
 
 
+class WithdrawRequest(BaseModel):
+    """회원 탈퇴 요청 (탈퇴 사유 선택 입력)"""
+
+    reason: Annotated[
+        str | None,
+        Field(None, max_length=500, description="탈퇴 사유 (선택, 최대 500자)"),
+    ]
+
+
 class WithdrawResponse(BaseModel):
     message: str

--- a/backend/app/models/prediction_results.py
+++ b/backend/app/models/prediction_results.py
@@ -42,10 +42,10 @@ class PredictionResult(Base):
         Enum(RiskLevelEnum, values_callable=lambda x: [e.value for e in x]),
         nullable=False, comment="low / moderate / medium / high / very_high"
     )
-    top_risk_factors: Mapped[dict | None] = mapped_column(JSON, nullable=True, comment="SHAP 기반 위험 요인 상위 3개")
+    top_risk_factors: Mapped[list | None] = mapped_column(JSON, nullable=True, comment="SHAP 기반 위험 요인 상위 3개")
     ai_evaluation: Mapped[str | None] = mapped_column(Text, nullable=True, comment="ChatGPT 수치 평가 코멘트")
     ai_alert: Mapped[str | None] = mapped_column(Text, nullable=True, comment="ChatGPT 위험 경고 (없으면 null)")
-    ai_missions: Mapped[dict | None] = mapped_column(JSON, nullable=True, comment="ChatGPT 추천 챌린지 3개")
+    ai_missions: Mapped[list | None] = mapped_column(JSON, nullable=True, comment="ChatGPT 추천 챌린지 3개")
     ai_encouragement: Mapped[str | None] = mapped_column(Text, nullable=True, comment="ChatGPT 동기부여 문장")
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(), comment="생성 시각"

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -29,6 +29,7 @@ class User(Base):
     current_point: Mapped[int] = mapped_column(Integer, nullable=False, default=0, comment="현재 보유 포인트")
     is_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, comment="탈퇴 여부 (Soft Delete)")
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, comment="탈퇴 처리 시각")
+    withdraw_reason: Mapped[str | None] = mapped_column(String(500), nullable=True, comment="탈퇴 사유 (재가입 시 초기화)")
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now(), comment="계정 생성 시각")
 
     @hybrid_property

--- a/backend/app/repositories/prediction_result_repository.py
+++ b/backend/app/repositories/prediction_result_repository.py
@@ -1,0 +1,87 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.health import HealthRecord
+from app.models.prediction_results import PredictionResult, TriggerTypeEnum
+
+
+class PredictionResultRepository:
+    """
+    PredictionResult 테이블에 대한 DB CRUD를 담당하는 레포지토리 클래스.
+    서비스 계층(services/)에서 호출되며, SQLAlchemy AsyncSession을 통해 DB와 통신한다.
+    """
+
+    def __init__(self, session: AsyncSession):
+        # 외부에서 주입받은 DB 세션 (FastAPI의 Depends를 통해 전달됨)
+        self._session = session
+        self._model = PredictionResult
+
+    async def create(self, data: dict) -> PredictionResult:
+        """
+        예측 결과를 신규 저장.
+        commit 후 refresh하여 DB 자동 생성 값(id, created_at)을 반영한다.
+        """
+        result = self._model(**data)
+        self._session.add(result)
+        await self._session.commit()
+        await self._session.refresh(result)
+        return result
+
+    async def get_by_id(self, result_id: int) -> PredictionResult | None:
+        """예측 결과 ID(PK)로 단건 조회. 없으면 None 반환."""
+        row = await self._session.execute(select(self._model).where(self._model.id == result_id))
+        return row.scalar_one_or_none()
+
+    async def get_latest_by_record_id(self, record_id: int) -> PredictionResult | None:
+        """특정 건강검진 기록의 가장 최근 예측 결과 단건 조회."""
+        row = await self._session.execute(
+            select(self._model)
+            .where(self._model.record_id == record_id)
+            .order_by(self._model.created_at.desc())
+            .limit(1)
+        )
+        return row.scalar_one_or_none()
+
+    async def get_list_by_record_id(self, record_id: int) -> list[PredictionResult]:
+        """특정 건강검진 기록의 전체 예측 결과 목록 조회 (최신순)."""
+        rows = await self._session.execute(
+            select(self._model)
+            .where(self._model.record_id == record_id)
+            .order_by(self._model.created_at.desc())
+        )
+        return list(rows.scalars().all())
+
+    async def get_list_by_user(self, user_id: int, limit: int = 20) -> list[PredictionResult]:
+        """
+        특정 사용자의 전체 예측 결과 목록 조회 (최신순, health_records JOIN).
+        limit으로 최대 반환 건수를 제한한다.
+        """
+        rows = await self._session.execute(
+            select(self._model)
+            .join(HealthRecord, self._model.record_id == HealthRecord.id)
+            .where(HealthRecord.user_id == user_id)
+            .order_by(self._model.created_at.desc())
+            .limit(limit)
+        )
+        return list(rows.scalars().all())
+
+    async def get_latest_by_user(self, user_id: int) -> PredictionResult | None:
+        """특정 사용자의 가장 최근 예측 결과 단건 조회."""
+        row = await self._session.execute(
+            select(self._model)
+            .join(HealthRecord, self._model.record_id == HealthRecord.id)
+            .where(HealthRecord.user_id == user_id)
+            .order_by(self._model.created_at.desc())
+            .limit(1)
+        )
+        return row.scalar_one_or_none()
+
+    async def exists_by_record_and_trigger(self, record_id: int, trigger_type: TriggerTypeEnum) -> bool:
+        """동일 건강검진 기록 + 트리거 타입 조합의 중복 저장 여부 확인."""
+        row = await self._session.execute(
+            select(self._model.id)
+            .where(self._model.record_id == record_id)
+            .where(self._model.trigger_type == trigger_type)
+            .limit(1)
+        )
+        return row.scalar_one_or_none() is not None

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Any
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.users import User
@@ -19,7 +20,7 @@ class UserRepository:
 
     async def get_user(self, user_id: int) -> User | None:
         """
-        사용자 ID(PK)로 단일 사용자를 조회한다. 
+        사용자 ID(PK)로 단일 사용자를 조회한다.
         없으면 None 반환.
         """
         result = await self._session.execute(
@@ -69,12 +70,44 @@ class UserRepository:
         await self._session.commit()
         await self._session.refresh(user)
 
-    async def hard_delete_user(self, user: User) -> None:
+    async def soft_delete_user(self, user: User, reason: str | None = None) -> None:
         """
-        사용자 계정을 DB에서 영구 삭제한다. (복구 불가)
-        Soft Delete(is_deleted 플래그)와 달리 실제 레코드를 제거한다.
+        사용자 계정을 Soft Delete 처리한다.
+        is_deleted=True, deleted_at=현재 시각으로 설정하며 실제 레코드는 유지된다.
+        탈퇴 사유(reason)가 전달되면 withdraw_reason에 저장한다.
+        외래키 제약 조건(health_records 등 자식 테이블)을 위반하지 않는다.
+        인증 의존성(get_request_user)에서 is_deleted=True인 사용자를 자동으로 차단한다.
         """
-        await self._session.execute(
-            delete(self._model).where(self._model.id == user.id)
-        )
+        user.is_deleted = True
+        user.deleted_at = datetime.now()
+        user.withdraw_reason = reason
         await self._session.commit()
+
+    async def restore_user(self, user: User) -> None:
+        """
+        탈퇴 후 7일 이내 재로그인 시 계정을 복구한다.
+        is_deleted=False, deleted_at=None, withdraw_reason=None으로 되돌리며
+        기존 프로필 데이터는 모두 유지된다.
+        """
+        user.is_deleted = False
+        user.deleted_at = None
+        user.withdraw_reason = None
+        await self._session.commit()
+        await self._session.refresh(user)
+
+    async def reset_user(self, user: User, nickname: str) -> None:
+        """
+        탈퇴 후 7일 초과 재로그인 시 계정을 초기 상태로 완전 리셋한다.
+        프로필(gender, birth_year), 포인트, 캐릭터 단계, 탈퇴 사유를 초기화한다.
+        nickname은 Google 계정 이름으로 갱신된다.
+        """
+        user.is_deleted = False
+        user.deleted_at = None
+        user.withdraw_reason = None
+        user.nickname = nickname
+        user.gender = None
+        user.birth_year = None
+        user.character_stage = 0
+        user.current_point = 0
+        await self._session.commit()
+        await self._session.refresh(user)

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -19,8 +19,10 @@ from starlette import status
 from app.core.config import Config
 from app.dtos.analysis import AnalysisResultResponse, AnalysisTaskResponse, GuestAnalysisRequest
 from app.models.health import HealthRecord
+from app.models.prediction_results import TriggerTypeEnum
 from app.models.users import User
 from app.repositories.health_repository import HealthRecordRepository
+from app.repositories.prediction_result_repository import PredictionResultRepository
 
 logger = logging.getLogger(__name__)
 
@@ -48,13 +50,22 @@ _celery_result = Celery(
 # 캐시 TTL: 24시간
 CACHE_TTL = 86400
 
+# task_meta TTL: 24시간 (task_id → record_id 매핑 보존 기간)
+TASK_META_TTL = 86400
+
 
 class HealthAnalysisService:
     """건강검진 AI 분석 비즈니스 로직"""
 
     def __init__(self, session: AsyncSession, redis: Redis):
-        self.repo = HealthRecordRepository(session)
+        self.health_repo = HealthRecordRepository(session)
+        self.prediction_repo = PredictionResultRepository(session)
         self.redis = redis
+
+    @property
+    def repo(self) -> HealthRecordRepository:
+        """하위 호환성 유지용 프로퍼티 (기존 self.repo 참조 유지)"""
+        return self.health_repo
 
     async def request_analysis(self, record_id: int, user: User) -> AnalysisResultResponse | AnalysisTaskResponse:
         """
@@ -98,6 +109,10 @@ class HealthAnalysisService:
             args=[user_data, nickname, challenge_days],
         )
         logger.info("ML1 분석 task 제출 - user_id: %d, task_id: %s", user.id, task.id)
+
+        # 5. task_id → record_id 매핑을 Redis에 저장 (결과 수신 시 DB 저장에 사용)
+        task_meta = json.dumps({"record_id": record_id, "trigger_type": TriggerTypeEnum.NEW_RECORD.value})
+        await self.redis.set(f"ml1:task_meta:{task.id}", task_meta, ex=TASK_META_TTL)
 
         return AnalysisTaskResponse(task_id=task.id, status="pending")
 
@@ -157,10 +172,9 @@ class HealthAnalysisService:
         if result.state == "SUCCESS":
             task_result = result.result
             if isinstance(task_result, dict) and task_result.get("status") == "success":
-                return AnalysisResultResponse(
-                    status="success",
-                    data=task_result.get("data"),
-                )
+                data = task_result.get("data")
+                await self._persist_prediction_result(task_id, data)
+                return AnalysisResultResponse(status="success", data=data)
             return AnalysisResultResponse(status="success", data=task_result)
 
         if result.state == "FAILURE":
@@ -169,6 +183,104 @@ class HealthAnalysisService:
 
         # RETRY, STARTED 등 기타 상태
         return AnalysisResultResponse(status="pending")
+
+    async def get_prediction_history(self, user_id: int, limit: int = 20) -> list:
+        """
+        사용자의 예측 결과 목록 조회 (최신순).
+        prediction_results → health_records JOIN으로 본인 기록만 반환한다.
+        """
+        return await self.prediction_repo.get_list_by_user(user_id, limit=limit)
+
+    async def get_prediction_result_by_record(self, record_id: int, user: User) -> list:
+        """
+        특정 건강검진 기록의 예측 결과 목록 조회.
+        소유권 검증 후 반환한다.
+        """
+        record = await self.health_repo.get_record(record_id)
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="해당 건강검진 기록을 찾을 수 없습니다.",
+            )
+        if record.user_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="본인의 건강검진 기록만 조회할 수 있습니다.",
+            )
+        return await self.prediction_repo.get_list_by_record_id(record_id)
+
+    async def _persist_prediction_result(self, task_id: str, data: dict | None) -> None:
+        """
+        Celery task 완료 시 예측 결과를 prediction_results DB에 저장.
+        - Redis task_meta에서 record_id, trigger_type을 조회한다.
+        - 중복 저장 방지: ml1:result_saved:{task_id} 플래그 확인
+        - data가 없거나 task_meta가 없으면 조용히 종료 (비회원 분석 등)
+        """
+        if not data:
+            return
+
+        # 중복 저장 방지 확인
+        saved_flag = await self.redis.get(f"ml1:result_saved:{task_id}")
+        if saved_flag:
+            return
+
+        # task_meta에서 record_id, trigger_type 조회
+        raw_meta = await self.redis.get(f"ml1:task_meta:{task_id}")
+        if not raw_meta:
+            # 비회원 분석 또는 메타 만료 → 저장 불필요
+            return
+
+        meta = json.loads(raw_meta)
+        record_id = meta.get("record_id")
+        trigger_type_value = meta.get("trigger_type", TriggerTypeEnum.NEW_RECORD.value)
+
+        if not record_id:
+            return
+
+        # ML1 결과 데이터 파싱 (ml1_predict, ml1_comment 구조)
+        # data.get()의 기본값 {}은 키가 없을 때만 적용되므로,
+        # 키는 있지만 값이 None인 경우를 대비해 'or {}'로 None 방어 처리
+        ml1_predict = data.get("ml1_predict") or {}
+        ml1_comment = data.get("ml1_comment") or {}
+
+        # predict()가 반환하는 한글 risk_grade → DB 영문 enum 변환
+        _risk_grade_map = {
+            "낮음": "low",
+            "보통": "moderate",
+            "중간": "medium",
+            "높음": "high",
+            "매우높음": "very_high",
+        }
+        risk_level = _risk_grade_map.get(ml1_predict.get("risk_grade", ""))
+
+        prediction_data = {
+            "record_id": record_id,
+            "trigger_type": trigger_type_value,
+            # predict() 반환 키: risk_percent, heart_age, risk_grade, top_risk_factors
+            "cvd_risk_percent": ml1_predict.get("risk_percent"),
+            "cvd_age": ml1_predict.get("heart_age"),
+            "risk_level": risk_level,
+            "top_risk_factors": ml1_predict.get("top_risk_factors"),
+            # ml1_comment() (GPT 응답) 반환 키: evaluation, alert, missions, encouragement
+            "ai_evaluation": ml1_comment.get("evaluation"),
+            "ai_alert": ml1_comment.get("alert"),
+            "ai_missions": ml1_comment.get("missions"),
+            "ai_encouragement": ml1_comment.get("encouragement"),
+        }
+
+        # 필수 필드(cvd_risk_percent, cvd_age, risk_level) 누락 시 저장 스킵
+        if not all([prediction_data["cvd_risk_percent"], prediction_data["cvd_age"], prediction_data["risk_level"]]):
+            logger.warning("ML1 결과 필수 필드 누락 - task_id: %s, data: %s", task_id, ml1_predict)
+            return
+
+        try:
+            await self.prediction_repo.create(prediction_data)
+            # 중복 저장 방지 플래그 설정 (24시간 TTL)
+            await self.redis.set(f"ml1:result_saved:{task_id}", "1", ex=TASK_META_TTL)
+            logger.info("예측 결과 DB 저장 완료 - task_id: %s, record_id: %d", task_id, record_id)
+        except Exception as e:
+            # DB 저장 실패는 결과 반환에 영향을 주지 않도록 로그만 남김
+            logger.error("예측 결과 DB 저장 실패 - task_id: %s, error: %s", task_id, e)
 
     # ──────────────────────────────────────────────
     # 데이터 변환 (private)

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,6 +11,9 @@ from app.repositories.user_repository import UserRepository
 from app.services.google_oauth import GoogleOAuthService, GoogleUserInfo
 from app.services.jwt import JwtService
 from app.utils.jwt.tokens import AccessToken, RefreshToken
+
+# 탈퇴 후 계정 복구 가능 기간
+RESTORE_PERIOD_DAYS = 7
 
 # __name__: 현재 모듈 경로(app.services.auth)를 로거 이름으로 사용
 # 로그 출력 시 어떤 파일에서 발생한 로그인지 자동 식별 가능
@@ -84,12 +88,44 @@ class AuthService:
             logger.info("기존 사용자 로그인 - user_id: %d", user.id)
 
         if user.is_deleted:
-            logger.warning("비활성화된 계정 로그인 시도 - user_id: %d", user.id)
-            raise HTTPException(
-                status_code=status.HTTP_423_LOCKED,
-                detail="비활성화된 계정입니다.",
-            )
+            is_new_user = await self._handle_withdrawn_user(user, google_user.name)
 
-        tokens = self.jwt_service.issue_jwt_pair(user) # token 발급되는 곳
+        tokens = self.jwt_service.issue_jwt_pair(user)
         logger.info("JWT 토큰 발급 완료 - user_id: %d, is_new_user: %s", user.id, is_new_user)
         return LoginResult(tokens=tokens, user=user, is_new_user=is_new_user)
+
+    async def _handle_withdrawn_user(self, user: User, google_name: str) -> bool:
+        """
+        탈퇴한 사용자의 재로그인 처리.
+
+        - 탈퇴 후 7일 이내: 계정 복구 (기존 데이터 유지, is_new_user=False)
+        - 탈퇴 후 7일 초과: 프로필 완전 초기화 (is_new_user=True → 초기 프로필 설정 필요)
+
+        Returns:
+            is_new_user (bool): 프론트엔드가 초기 프로필 설정 화면으로 안내할지 여부
+        """
+        if user.deleted_at is None:
+            # deleted_at이 없는 비정상 상태 → 복구 처리
+            logger.warning("deleted_at 누락된 탈퇴 계정 복구 - user_id: %d", user.id)
+            await self.user_repo.restore_user(user)
+            return False
+
+        restore_deadline = user.deleted_at + timedelta(days=RESTORE_PERIOD_DAYS)
+        is_restorable = datetime.now() <= restore_deadline
+
+        if is_restorable:
+            # 7일 이내: 기존 데이터 유지하며 계정 복구
+            logger.info(
+                "계정 복구 처리 - user_id: %d, deleted_at: %s, deadline: %s",
+                user.id, user.deleted_at, restore_deadline,
+            )
+            await self.user_repo.restore_user(user)
+            return False
+        else:
+            # 7일 초과: 프로필 초기화 후 신규 사용자로 처리
+            logger.info(
+                "계정 초기화 처리 - user_id: %d, deleted_at: %s (7일 초과)",
+                user.id, user.deleted_at,
+            )
+            await self.user_repo.reset_user(user, nickname=google_name[:20])
+            return True

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -47,9 +47,14 @@ class UserManageService:
         await self.repo.update_instance(user=user, data=update_data)
         return user
 
-    async def withdraw_user(self, user: User) -> None:
-        """사용자의 계정과 모든 관련 데이터를 영구적으로 삭제한다."""
-        await self.repo.hard_delete_user(user)
+    async def withdraw_user(self, user: User, reason: str | None = None) -> None:
+        """
+        사용자 탈퇴 처리 (Soft Delete).
+        is_deleted=True, deleted_at=현재 시각으로 마킹하며 실제 레코드는 유지된다.
+        탈퇴 사유는 선택 입력이며 withdraw_reason 컬럼에 저장된다.
+        이후 인증 시 get_request_user에서 자동으로 접근이 차단된다.
+        """
+        await self.repo.soft_delete_user(user, reason=reason)
 
     async def get_dashboard(self, user: User) -> DashboardResponse:
         """마이페이지 대시보드에 표시할 건강 현황 요약 정보를 반환한다."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "cryptography>=46.0.3",
     "fastapi>=0.128.0",
     "joblib>=1.5.3",
+    "langfuse>=4.2.0",
     "numpy>=2.4.1",
     "openai>=2.30.0",
     "pandas>=3.0.2",

--- a/scripts/gen_token.py
+++ b/scripts/gen_token.py
@@ -1,0 +1,86 @@
+"""
+로컬 테스트용 Access Token 발급 스크립트.
+
+사용법:
+    uv run python scripts/gen_token.py --user-id 1
+    uv run python scripts/gen_token.py --user-id 1 --env envs/.local.env
+
+주의:
+    - 서버와 동일한 SECRET_KEY를 사용해야 토큰 검증이 통과된다.
+    - .env 또는 envs/.local.env 파일의 SECRET_KEY가 서버와 일치하는지 확인한다.
+    - 이 스크립트는 로컬 개발/테스트 전용으로, 프로덕션 환경에서 사용 금지.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# 프로젝트 루트 기준으로 backend/ 를 파이썬 경로에 추가
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+
+def load_env(env_file: str) -> None:
+    """지정된 env 파일을 환경변수로 로드."""
+    env_path = PROJECT_ROOT / env_file
+    if not env_path.exists():
+        print(f"[경고] env 파일을 찾을 수 없음: {env_path}")
+        print("  → 기본 설정(config.py default)으로 진행합니다.")
+        return
+
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            os.environ.setdefault(key.strip(), value.strip())
+
+    print(f"[정보] env 파일 로드 완료: {env_path}")
+
+
+def generate_token(user_id: int) -> str:
+    """주어진 user_id로 AccessToken을 생성하고 문자열로 반환."""
+    # env 로드 이후에 import (SECRET_KEY 등이 먼저 환경변수에 설정되어야 함)
+    from app.utils.jwt.tokens import AccessToken
+    from app.core import config as cfg
+
+    class _MockUser:
+        """AccessToken.for_user()가 필요로 하는 최소 User 객체."""
+        def __init__(self, uid: int):
+            self.id = uid
+
+    token = AccessToken.for_user(_MockUser(user_id))
+    token_str = str(token)
+
+    print(f"\n{'=' * 60}")
+    print(f"  User ID    : {user_id}")
+    print(f"  Token Type : access")
+    print(f"  Algorithm  : {cfg.JWT_ALGORITHM}")
+    print(f"  Expire     : {cfg.ACCESS_TOKEN_EXPIRE_MINUTES // 60 // 24}일 후 만료")
+    print(f"{'=' * 60}")
+    print(f"\n[Access Token]\n{token_str}\n")
+    print("[사용 방법] Swagger UI → Authorize → Bearer {위 토큰 붙여넣기}")
+    print("[사용 방법] curl -H 'Authorization: Bearer {위 토큰}' http://localhost:8000/...\n")
+
+    return token_str
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="로컬 테스트용 Access Token 발급 스크립트")
+    parser.add_argument("--user-id", type=int, required=True, help="토큰을 발급할 사용자 ID (users.id)")
+    parser.add_argument(
+        "--env",
+        type=str,
+        default="envs/.local.env",
+        help="env 파일 경로 (프로젝트 루트 기준, 기본값: envs/.local.env)",
+    )
+    args = parser.parse_args()
+
+    load_env(args.env)
+    generate_token(args.user_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -206,6 +215,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -592,6 +658,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -741,6 +819,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -843,6 +933,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/9c/b912a00ffae92ff9955cdd9b74fb839be58f631d4329ae2a8a0376f697f2/langfuse-4.2.0.tar.gz", hash = "sha256:d0bd26d5065cf6a59d7d1093b08d8910e2458dc3da7ed8ccec160db114c18342", size = 275582, upload-time = "2026-04-10T11:55:25.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/0a/b84e3e68a690ccfe6d64953c572772c685fcb0915b7f2ee3a87c22e388ab/langfuse-4.2.0-py3-none-any.whl", hash = "sha256:bfd760bf10fd0228f297f6369436620f76d16b589de46393d65706b27e4e4082", size = 475449, upload-time = "2026-04-10T11:55:23.624Z" },
 ]
 
 [[package]]
@@ -1015,6 +1124,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "joblib" },
+    { name = "langfuse" },
     { name = "numpy" },
     { name = "openai" },
     { name = "pandas" },
@@ -1065,6 +1175,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "joblib", specifier = ">=1.5.3" },
+    { name = "langfuse", specifier = ">=4.2.0" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pandas", specifier = ">=3.0.2" },
@@ -1406,6 +1517,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1596,6 +1789,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1916,6 +2124,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/0d/3a6cfa9ae99606afb612d8fb7a66b245a9d5ff0f29bb347c8a30b6ad561b/regex-2026.1.15-cp314-cp314t-win32.whl", hash = "sha256:e90b8db97f6f2c97eb045b51a6b2c5ed69cedd8392459e0642d4199b94fabd7e", size = 274667, upload-time = "2026-01-14T23:17:19.301Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b2/297293bb0742fd06b8d8e2572db41a855cdf1cae0bf009b1cb74fe07e196/regex-2026.1.15-cp314-cp314t-win_amd64.whl", hash = "sha256:5ef19071f4ac9f0834793af85bd04a920b4407715624e40cb7a0631a11137cdf", size = 284386, upload-time = "2026-01-14T23:17:21.231Z" },
     { url = "https://files.pythonhosted.org/packages/95/e4/a3b9480c78cf8ee86626cb06f8d931d74d775897d44201ccb813097ae697/regex-2026.1.15-cp314-cp314t-win_arm64.whl", hash = "sha256:ca89c5e596fc05b015f27561b3793dc2fa0917ea0d7507eebb448efd35274a70", size = 274837, upload-time = "2026-01-14T23:17:23.146Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -2785,6 +3008,45 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
 name = "xgboost"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2800,4 +3062,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
     { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
     { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## 📌 작업 내용
### 회원탈퇴
- 회원 탈퇴 시 탈퇴여부 및 탈퇴날짜를 저장하여 Soft Delete 형태로 전환
- 기준이 되는 날짜 전후에 따라 아래 동작 (기준 날짜 : 7일)
   - 기준 날짜 전 : 기존 데이터 복구
   - 기준 날짜 후 : 데이터 초기화 및 새로 가입

### ML1 예측 결과 DB 저장
- 분석 요청 시 생성되는 결과를 prediction_results 테이블을 생성하여 해당 테이블에 저장
- 분석 결과를 저장하는 테이블 구현

### Langfuse 연동
- Langfuse 연동 및 결과 확인

## 🔄 변경 파일
- 

## ✅ 테스트
- [x] 백엔드 동작 Swagger로 Test

## 🔗 관련 평가 항목
- Close #50
- #51
