### PR TITLE
[BE] feat: 챌린지/Vision API JWT 인증 적용

### DIFF
--- a/backend/app/apis/v1/ai_vision_routers.py
+++ b/backend/app/apis/v1/ai_vision_routers.py
@@ -13,7 +13,7 @@ ML2 Vision API 라우터 — 식단 분석 / 운동 캡처 인증 엔드포인�
 import base64
 from typing import Annotated
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import JSONResponse as Response
 
 from app.dtos.ai_vision import (
@@ -23,6 +23,8 @@ from app.dtos.ai_vision import (
 )
 from app.services.ai_vision_service import AIVisionService
 from app.utils.pubsub import wait_task_result
+from app.dependencies.security import get_request_user
+from app.models.users import User
 
 # 허용 MIME 타입 (OpenAI Vision API 지원 형식)
 _ALLOWED_MEDIA_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
@@ -80,6 +82,7 @@ def _validate_and_encode(image: UploadFile, image_bytes: bytes) -> tuple[str, st
 )
 async def analyze_meal_free(
     image: Annotated[UploadFile, File(description="식단 이미지 파일 (JPEG, PNG, WebP, GIF)")],
+    current_user: Annotated[User, Depends(get_request_user)],
     risk_factors: Annotated[str, Form(description="사용자 위험 요인 (예: 고혈압, 당뇨)")] = "",
 ) -> Response:
     image_bytes = await image.read()
@@ -118,9 +121,10 @@ async def analyze_meal_free(
 )
 async def analyze_meal_paid(
     image: Annotated[UploadFile, File(description="식단 이미지 파일 (JPEG, PNG, WebP, GIF)")],
+    current_user: Annotated[User, Depends(get_request_user)],
     risk_factors: Annotated[str, Form(description="사용자 위험 요인 (예: 고혈압, 당뇨)")] = "",
 ) -> Response:
-    # TODO: 포인트 차감 로직 추가 (user_id 필요 → 인증 미들웨어 연결 후)
+    # TODO: 포인트 차감 로직 추가 (current_user.id 사용)
     image_bytes = await image.read()
     image_base64, media_type = _validate_and_encode(image, image_bytes)
 
@@ -160,6 +164,7 @@ async def analyze_meal_paid(
 )
 async def analyze_exercise(
     image: Annotated[UploadFile, File(description="운동 앱 스크린샷 파일 (JPEG, PNG, WebP, GIF)")],
+    current_user: Annotated[User, Depends(get_request_user)],
 ) -> Response:
     image_bytes = await image.read()
     image_base64, media_type = _validate_and_encode(image, image_bytes)

--- a/backend/app/apis/v1/challenge_routers.py
+++ b/backend/app/apis/v1/challenge_routers.py
@@ -12,7 +12,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse as Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +27,8 @@ from app.dtos.challenge import (
     UserChallengeResponse,
 )
 from app.services.challenge_service import ChallengeService
+from app.dependencies.security import get_request_user
+from app.models.users import User
 
 # /api/v1/challenges 경로의 라우터
 challenge_router = APIRouter(prefix="/challenges", tags=["challenges"])
@@ -97,11 +99,11 @@ async def get_challenges(
 async def join_challenge(
     challenge_id: int,
     session: Annotated[AsyncSession, Depends(get_db_session)],
-    user_id: int = Query(..., description="사용자 ID (추후 인증 미들웨어로 대체)"),
+    current_user: Annotated[User, Depends(get_request_user)],
 ) -> Response:
     service = ChallengeService(session)
     user_challenge = await service.join_challenge(
-        user_id=user_id,
+        user_id=current_user.id,
         challenge_id=challenge_id,
     )
 
@@ -133,15 +135,20 @@ async def join_challenge(
     responses={
         200: {"description": "포기 처리 완료", "model": MessageResponse},
         400: {"description": "이미 완료/포기된 챌린지", "model": ErrorResponse},
+        403: {"description": "본인 챌린지가 아님", "model": ErrorResponse},
         404: {"description": "존재하지 않는 참여 기록", "model": ErrorResponse},
     },
 )
 async def abandon_challenge(
     user_challenge_id: int,
     session: Annotated[AsyncSession, Depends(get_db_session)],
+    current_user: Annotated[User, Depends(get_request_user)],
 ) -> Response:
     service = ChallengeService(session)
-    await service.abandon_challenge(user_challenge_id)
+    await service.abandon_challenge(
+        user_challenge_id=user_challenge_id,
+        user_id=current_user.id,
+    )
 
     return Response(
         content=MessageResponse(
@@ -166,6 +173,7 @@ async def abandon_challenge(
     responses={
         201: {"description": "인증 성공", "model": ChallengeLogResponse},
         400: {"description": "이미 완료/포기된 챌린지", "model": ErrorResponse},
+        403: {"description": "본인 챌린지가 아님", "model": ErrorResponse},
         404: {"description": "존재하지 않는 참여 기록", "model": ErrorResponse},
         409: {"description": "오늘 이미 인증 완료", "model": ErrorResponse},
     },
@@ -174,10 +182,12 @@ async def log_daily(
     user_challenge_id: int,
     request: ChallengeLogRequest,
     session: Annotated[AsyncSession, Depends(get_db_session)],
+    current_user: Annotated[User, Depends(get_request_user)],
 ) -> Response:
     service = ChallengeService(session)
     log = await service.log_daily(
         user_challenge_id=user_challenge_id,
+        user_id=current_user.id,
         verification_type=request.verification_type,
         input_value=request.input_value,
         cv_result_id=request.cv_result_id,

--- a/backend/app/services/challenge_service.py
+++ b/backend/app/services/challenge_service.py
@@ -87,16 +87,24 @@ class ChallengeService:
     # 3. 챌린지 포기
     # ══════════════════════════════════════════
 
-    async def abandon_challenge(self, user_challenge_id: int) -> UserChallenge:
+    async def abandon_challenge(
+        self, user_challenge_id: int, user_id: int
+    ) -> UserChallenge:
         """
         챌린지 포기 처리
         검증:
           - user_challenge 존재 여부 (404)
+          - 소유권 (403) — 본인 챌린지만 포기 가능
           - active 상태만 포기 가능 (400)
         """
-        logger.info("챌린지 포기 요청 - user_challenge_id: %d", user_challenge_id)
+        logger.info(
+            "챌린지 포기 요청 - user_challenge_id: %d, user_id: %d",
+            user_challenge_id, user_id,
+        )
 
-        user_challenge = await self._get_active_user_challenge(user_challenge_id)
+        user_challenge = await self._get_active_user_challenge(
+            user_challenge_id, user_id
+        )
 
         updated = await self.repo.update_status(
             user_challenge, UserChallengeStatusEnum.ABANDONED
@@ -111,6 +119,7 @@ class ChallengeService:
     async def log_daily(
         self,
         user_challenge_id: int,
+        user_id: int,
         verification_type: VerificationMethodEnum,
         input_value: str | None = None,
         cv_result_id: int | None = None,
@@ -119,6 +128,7 @@ class ChallengeService:
         챌린지 인증 기록
         검증:
           - user_challenge 존재 여부 (404)
+          - 소유권 (403) — 본인 챌린지만 인증 가능
           - active 상태만 인증 가능 (400)
           - 하루 1회 인증 제한 (409)
         처리:
@@ -126,9 +136,14 @@ class ChallengeService:
           - current_streak 업데이트
           - 챌린지 기간 종료 시(마지막 날 포함) 최종 판정
         """
-        logger.info("챌린지 인증 요청 - user_challenge_id: %d", user_challenge_id)
+        logger.info(
+            "챌린지 인증 요청 - user_challenge_id: %d, user_id: %d",
+            user_challenge_id, user_id,
+        )
 
-        user_challenge = await self._get_active_user_challenge(user_challenge_id)
+        user_challenge = await self._get_active_user_challenge(
+            user_challenge_id, user_id
+        )
 
         # 하루 1회 인증 제한
         today = date.today()
@@ -193,11 +208,16 @@ class ChallengeService:
     # ══════════════════════════════════════════
 
     async def _get_active_user_challenge(
-        self, user_challenge_id: int
+        self, user_challenge_id: int, user_id: int
     ) -> UserChallenge:
         """
-        user_challenge 조회 + active 상태 검증
+        user_challenge 조회 + 소유권 검증 + active 상태 검증
         포기, 챌린지 인증에서 공통으로 사용
+
+        검증 순서 (중요):
+          1. 존재 여부 (404)
+          2. 소유권 (403) — JWT로 인증된 user_id와 user_challenge.user_id 비교
+          3. active 상태 (400)
         """
         user_challenge = await self.repo.get_user_challenge_by_id(user_challenge_id)
 
@@ -205,6 +225,17 @@ class ChallengeService:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"참여 중인 챌린지를 찾을 수 없습니다. (id: {user_challenge_id})",
+            )
+
+        # 소유권 검증: 본인 챌린지가 아니면 403
+        if user_challenge.user_id != user_id:
+            logger.warning(
+                "소유권 검증 실패 - user_challenge_id: %d, owner_id: %d, requester_id: %d",
+                user_challenge_id, user_challenge.user_id, user_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="본인의 챌린지가 아닙니다.",
             )
 
         if user_challenge.status != UserChallengeStatusEnum.ACTIVE:


### PR DESCRIPTION
Closes #57

## 📌 작업 내용
기존 `?user_id=N` 쿼리 파라미터 방식 제거 → JWT Access Token 기반 인증 적용

## 변경 엔드포인트 (6개)
**challenge_routers.py**
- `POST /challenges/{challenge_id}/join` — 참여자를 토큰으로 식별
- `PATCH /user-challenges/{user_challenge_id}/abandon` — 인증 + 소유권 검증
- `POST /user-challenges/{user_challenge_id}/log` — 인증 + 소유권 검증

**ai_vision_routers.py**
- `POST /ai/meals/free` — 포인트 적립 대상 식별
- `POST /ai/meals/paid` — 포인트 차감 대상 식별
- `POST /ai/exercise` — 포인트 적립 대상 식별

## 🔄 변경 파일
- `backend/app/apis/v1/ai_vision_routers.py`
- `backend/app/apis/v1/challenge_routers.py`
- `backend/app/services/challenge_service.py`

## ✅ 테스트
- [x] 백엔드: 로컬 Swagger 기준 토큰 없이 6개 엔드포인트 호출 시 모두 `401 Unauthorized` 확인
  - `POST /challenges/1/join` → 401 ✅
  - `PATCH /user-challenges/1/abandon` → 401 ✅
  - `POST /user-challenges/1/log` → 401 ✅
  - `POST /ai/meals/free` → 401 ✅
  - `POST /ai/meals/paid` → 401 ✅
  - `POST /ai/exercise` → 401 ✅

## 🔗 관련 평가 항목
- 보안: JWT 기반 인증 적용

## 📝 리뷰어에게
- 

## 📸 스크린샷 (선택)
<img width="612" height="252" alt="image" src="https://github.com/user-attachments/assets/c18f728d-cd60-4c1e-899f-1d1708bc02e6" />
