### PR TITLE
[FE] feat: 구글 로그인 인가 코드 방식으로 변경

### DIFF
--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -1,36 +1,34 @@
-import { GoogleLogin } from "@react-oauth/google";
+import { useGoogleLogin } from "@react-oauth/google";
 
 const LoginPage = () => {
-  const handleGoogleSuccess = async (credentialResponse: any) => {
-    console.log("Google login success:", credentialResponse);
+  const login = useGoogleLogin({
+    onSuccess: async (codeResponse) => {
+      console.log("Google login success:", codeResponse);
 
-    const idToken = credentialResponse.credential;
+      try {
+        const res = await fetch("http://localhost:8000/api/v1/auth/login/google", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            code: codeResponse.code,
+          }),
+        });
 
-    try {
-      const res = await fetch("http://localhost:8080/auth/google", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          token: idToken,
-        }),
-      });
+          const data = await res.json();
+          console.log("Backend response:", data);
 
-      const data = await res.json();
-      console.log("Backend response:", data);
+          localStorage.setItem("accessToken", data.access_token);
+          window.location.href = "/dashboard";
+        } catch (error) {
+          console.error("Google login failed:", error);
+        }
+      },
+      onError: () => console.log("Google Login Failed"),
+      flow: "auth-code",
+  });
 
-      // 나중에 백엔드 연결되면 사용
-      // localStorage.setItem("accessToken", data.accessToken);
-      // window.location.href = "/dashboard";
-    } catch (error) {
-      console.error("Google login failed:", error);
-    }
-  };
-
-  const handleGoogleError = () => {
-    console.log("Google Login Failed");
-  };
 
   return (
     <div className="login-page">
@@ -85,10 +83,9 @@ const LoginPage = () => {
               </div>
 
               <div className="google-login-box">
-                <GoogleLogin
-                  onSuccess={handleGoogleSuccess}
-                  onError={handleGoogleError}
-                />
+                <button onClick={() => login()}>
+                  구글로 로그인
+                 </button>
               </div>
             </div>
 


### PR DESCRIPTION
## 📌 작업 내용
- 구글 로그인 방식을 ID 토큰 방식에서 인가 코드 방식으로 변경

## 🔄 **변경 전:**
FE → 구글 로그인 → ID 토큰 받음 → BE로 전달

## 🔄 **변경 후:**
FE → 구글 로그인 버튼 클릭
→ 구글 OAuth 페이지로 리다이렉트
→ 구글이 code 전달
→ BE가 code 받아서 처리

## 🔗 변경 파일
- `frontend/src/pages/Login/LoginPage.tsx`
  - GoogleLogin 컴포넌트 → useGoogleLogin 훅으로 변경
  - 구글 기본 버튼 → 커스텀 버튼으로 변경
  - flow: "auth-code" 적용

## ✅  테스트 결과
- [x] 로컬 환경 구글 로그인 성공 
- [ ] EC2 배포 환경 테스트

<img width="1596" height="882" alt="image" src="https://github.com/user-attachments/assets/84e6b353-7be7-4ab7-83b8-1429d89821af" />

<img width="1962" height="1354" alt="image" src="https://github.com/user-attachments/assets/fa2db41a-fcf3-4aa9-9117-9bf086a30144" />

## ✅  체크리스트
- [x] useGoogleLogin 적용
- [x] 커스텀 버튼으로 변경
- [x] 인가 코드 BE 전달 확인
- [x] 로컬 테스트 완
