### PR TITLE
 [BE] fix/feat/chore: AI 분석 보안 강화, 챌린지 시드 데이터, 게스트 분석 이전 API

### DIFF
--- a/backend/app/apis/v1/analysis_routers.py
+++ b/backend/app/apis/v1/analysis_routers.py
@@ -13,6 +13,7 @@ from app.dtos.analysis import (
     AnalysisResultResponse,
     AnalysisTaskResponse,
     GuestAnalysisRequest,
+    MigrateGuestAnalysisRequest,
     PredictionResultListResponse,
     PredictionResultResponse,
 )
@@ -85,6 +86,33 @@ async def request_guest_analysis(
 ) -> Response:
     service = HealthAnalysisService(session, redis)
     result = await service.request_guest_analysis(data)
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@analysis_router.post(
+    "/migrate-guest",
+    response_model=AnalysisResultResponse,
+    status_code=status.HTTP_200_OK,
+    summary="게스트 분석 결과 → 회원 계정 이전",
+    description=(
+        "비회원 분석 결과(guest_task_id)를 회원 건강검진 기록(record_id)에 연결하여 DB에 저장한다. "
+        "재분석 없이 기존 결과를 그대로 이전하므로 즉시 반환된다. "
+        "Celery 결과가 만료됐거나 없으면 404를 반환한다."
+    ),
+    responses={
+        200: {"description": "이전 성공", "model": AnalysisResultResponse},
+        403: {"description": "본인 기록이 아님"},
+        404: {"description": "게스트 분석 결과 없음 또는 건강검진 기록 없음"},
+    },
+)
+async def migrate_guest_analysis(
+    data: MigrateGuestAnalysisRequest,
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
+) -> Response:
+    service = HealthAnalysisService(session, redis)
+    result = await service.migrate_guest_analysis(data.guest_task_id, data.record_id, user)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
 
 

--- a/backend/app/apis/v1/analysis_routers.py
+++ b/backend/app/apis/v1/analysis_routers.py
@@ -1,13 +1,14 @@
+import json
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import ORJSONResponse as Response
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.redis import get_redis
 from app.db.databases import get_db_session
-from app.dependencies.security import get_request_user
+from app.dependencies.security import get_optional_user, get_request_user
 from app.dtos.analysis import (
     AnalysisResultResponse,
     AnalysisTaskResponse,
@@ -124,7 +125,18 @@ async def get_analysis_result(
     task_id: str,
     session: Annotated[AsyncSession, Depends(get_db_session)],
     redis: Annotated[Redis, Depends(get_redis)],
+    current_user: Annotated[User | None, Depends(get_optional_user)],
 ) -> Response:
+    if current_user is not None:
+        raw_meta = await redis.get(f"ml1:task_meta:{task_id}")
+        if raw_meta:
+            meta = json.loads(raw_meta)
+            task_user_id = meta.get("user_id")
+            if task_user_id is not None and task_user_id != current_user.id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="본인의 분석 결과만 조회할 수 있습니다.",
+                )
     service = HealthAnalysisService(session, redis)
     result = await service.get_analysis_result(task_id)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
@@ -150,7 +162,19 @@ async def wait_analysis_result(
     task_id: str,
     session: Annotated[AsyncSession, Depends(get_db_session)],
     redis: Annotated[Redis, Depends(get_redis)],
+    current_user: Annotated[User | None, Depends(get_optional_user)],
 ) -> Response:
+    if current_user is not None:
+        raw_meta = await redis.get(f"ml1:task_meta:{task_id}")
+        if raw_meta:
+            meta = json.loads(raw_meta)
+            task_user_id = meta.get("user_id")
+            if task_user_id is not None and task_user_id != current_user.id:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="본인의 분석 결과만 조회할 수 있습니다.",
+                )
+
     service = HealthAnalysisService(session, redis)
 
     # 1. 이미 완료된 결과가 있으면 즉시 반환 (Pub/Sub 구독 불필요)

--- a/backend/app/dependencies/security.py
+++ b/backend/app/dependencies/security.py
@@ -10,6 +10,7 @@ from app.repositories.user_repository import UserRepository
 from app.services.jwt import JwtService
 
 security = HTTPBearer()
+optional_security = HTTPBearer(auto_error=False)
 
 
 async def get_request_user(
@@ -25,3 +26,23 @@ async def get_request_user(
     if not user or user.is_deleted:
         raise HTTPException(detail="Authenticate Failed.", status_code=status.HTTP_401_UNAUTHORIZED)
     return user
+
+
+async def get_optional_user(
+    credential: Annotated[HTTPAuthorizationCredentials | None, Depends(optional_security)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> User | None:
+    if not credential:
+        return None
+    try:
+        token = credential.credentials
+        verified = JwtService().verify_jwt(token=token, token_type="access")
+        user_id = verified.payload.get("id")
+        if user_id is None:
+            return None
+        user = await UserRepository(session).get_user(user_id)
+        if not user or user.is_deleted:
+            return None
+        return user
+    except Exception:
+        return None

--- a/backend/app/dtos/analysis.py
+++ b/backend/app/dtos/analysis.py
@@ -56,6 +56,12 @@ class GuestAnalysisRequest(BaseModel):
         return self
 
 
+class MigrateGuestAnalysisRequest(BaseModel):
+    """게스트 분석 결과 → 회원 계정 이전 요청"""
+    guest_task_id: Annotated[str, Field(description="게스트 분석 task_id")]
+    record_id: Annotated[int, Field(description="회원 건강검진 기록 ID")]
+
+
 # ──────────────────────────────────────────────
 # Response DTOs
 # ──────────────────────────────────────────────

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -111,7 +111,7 @@ class HealthAnalysisService:
         logger.info("ML1 분석 task 제출 - user_id: %d, task_id: %s", user.id, task.id)
 
         # 5. task_id → record_id 매핑을 Redis에 저장 (결과 수신 시 DB 저장에 사용)
-        task_meta = json.dumps({"record_id": record_id, "trigger_type": TriggerTypeEnum.NEW_RECORD.value})
+        task_meta = json.dumps({"record_id": record_id, "trigger_type": TriggerTypeEnum.NEW_RECORD.value, "user_id": user.id})
         await self.redis.set(f"ml1:task_meta:{task.id}", task_meta, ex=TASK_META_TTL)
 
         return AnalysisTaskResponse(task_id=task.id, status="pending")

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -157,6 +157,39 @@ class HealthAnalysisService:
 
         return AnalysisTaskResponse(task_id=task.id, status="pending")
 
+    async def migrate_guest_analysis(self, guest_task_id: str, record_id: int, user: User) -> AnalysisResultResponse:
+        """
+        게스트 분석 결과를 회원 계정으로 이전.
+        1. record_id 소유권 검증
+        2. guest_task_id로 Celery 결과 조회
+        3. prediction_results DB에 저장 후 반환
+        """
+        record = await self.repo.get_record(record_id)
+        if not record:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="건강검진 기록을 찾을 수 없습니다.")
+        if record.user_id != user.id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="본인의 건강검진 기록만 사용할 수 있습니다.")
+
+        result = AsyncResult(guest_task_id, app=_celery_result)
+        if result.state != "SUCCESS":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="게스트 분석 결과를 찾을 수 없습니다. 다시 분석해주세요.")
+
+        task_result = result.result
+        data = task_result.get("data") if isinstance(task_result, dict) else None
+        if not data:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="게스트 분석 결과 데이터가 없습니다.")
+
+        task_meta = json.dumps({
+            "record_id": record_id,
+            "trigger_type": TriggerTypeEnum.NEW_RECORD.value,
+            "user_id": user.id,
+        })
+        await self.redis.set(f"ml1:task_meta:{guest_task_id}", task_meta, ex=TASK_META_TTL)
+        await self._persist_prediction_result(guest_task_id, data)
+        logger.info("게스트 분석 결과 회원 이전 완료 - user_id: %d, record_id: %d", user.id, record_id)
+
+        return AnalysisResultResponse(status="success", data=data)
+
     async def get_analysis_result(self, task_id: str) -> AnalysisResultResponse:
         """
         Celery task 결과 조회 (DB 1에서 조회).

--- a/scripts/seed_challenges.sql
+++ b/scripts/seed_challenges.sql
@@ -1,0 +1,22 @@
+-- 챌린지 시드 데이터
+-- 실행 전: challenge_logs, user_challenges 의존 데이터도 초기화됨에 주의
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE challenge_logs;
+TRUNCATE TABLE user_challenges;
+TRUNCATE TABLE challenges;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+INSERT INTO challenges (category, title, description, expected_effect, verification_method, target_risk_factors, duration_days, required_success_days) VALUES
+('diet',      '저염식사',        '오늘 하루 나트륨 2,000mg 이하로 줄여보세요',        '7일 지속 시 수축기 혈압 3mmHg 감소',              'checklist', '고혈압',         7,  5),
+('diet',      '포화지방 줄이기', '삼겹살, 버터 대신 생선과 견과류로 바꿔보세요',      '꾸준히 실천하면 나쁜 콜레스테롤 수치 개선',      'checklist', '고콜레스테롤',   7,  5),
+('diet',      '당류 줄이기',     '음료수, 과자 대신 과일로 당 섭취를 줄여보세요',    '꾸준히 실천하면 공복혈당 수치 안정화',            'checklist', '고혈당',         7,  5),
+('diet',      '야식 금지',       '저녁 9시 이후에는 아무것도 먹지 않아요',           '꾸준히 실천하면 체중 감소 및 BMI 개선',           'checklist', '과체중 (BMI 25+)', 7, 5),
+('exercise',  '유산소 운동 20분','빠르게 걷기, 자전거, 뛰기 20분 움직여보세요',      '7일 지속 시 혈압 4mmHg 감소, BMI 0.2 개선',      'checklist', '고혈압,과체중',  7,  5),
+('exercise',  '하루 7,000보',    '만보기 앱으로 오늘 7,000보를 채워보세요',          '꾸준히 실천하면 콜레스테롤 수치 개선',            'checklist', '고콜레스테롤',   7,  5),
+('exercise',  '식후 15분 걷기',  '밥 먹고 15분만 천천히 걸어보세요',                '꾸준히 실천하면 식후 혈당 스파이크 완화',         'checklist', '고혈당',         7,  5),
+('lifestyle', '물 2L 마시기',    '하루 8잔의 물로 혈액 순환을 도와주세요',           '충분한 수분 섭취 시 심혈관 질환 발생률 감소',     'checklist', '공통',           7,  5),
+('lifestyle', '금연 (단계별)',   '오늘 피운 담배 개비 수를 입력해주세요',            '완전 금연 시 심혈관 위험도 30% 감소',             'input',     '흡연자',         30, 21),
+('lifestyle', '금주 (단계별)',   '이번 주 음주 횟수를 기록해주세요',                 '완전 금주 시 혈압 및 심혈관 위험도 개선',         'input',     '음주자',         30, 21);


### PR DESCRIPTION
## 📌 개요
로그인한 유저가 타인의 AI 분석 결과를 조회할 수 있던 보안 문제를 수정했습니다.

## 📌 원인
`GET /api/v1/health/analysis/{task_id}` 엔드포인트에 유저 인증이 없어
`task_id`만 알면 누구든 타인의 분석 결과를 조회할 수 있었습니다.

## 🔄 변경 사항

### 🔒 AI 분석 결과 유저 소유권 검증 추가
기존에 `GET /api/v1/health/analysis/{task_id}` 엔드포인트에 인증이 없어
`task_id`만 알면 타인의 분석 결과를 조회할 수 있던 보안 문제를 수정했습니다.

- `security.py`: `get_optional_user` 의존성 추가 (토큰 없으면 None, 게스트 호환 유지)
- `analysis.py`: `task_meta`에 `user_id` 포함하여 Redis 저장
- `analysis_routers.py`: `GET /{task_id}`, `GET /{task_id}/wait` 소유권 검증 추가
  - 로그인 유저: task 소유자와 불일치 시 403 반환
  - 게스트(토큰 없음): 검증 없이 통과

### 🌱 챌린지 시드 데이터 추가
- `scripts/seed_challenges.sql` 신규 추가
- 총 10개 챌린지 (식습관 4, 운동 3, 생활습관 3)
- 기존 인코딩 깨진 데이터 초기화 후 재삽입

**EC2 적용 방법**
```bash
git pull origin develop
docker exec -i mysql mysql -uozcoding -ppw1234 ai_health < scripts/seed_challenges.sql
⚠️ 실행 시 challenge_logs, user_challenges 데이터도 초기화됩니다.

🔄 게스트 분석 결과 회원 계정 이전 API 추가
비회원 분석 후 로그인 시 분석을 재실행하던 비효율을 개선했습니다.

POST /api/v1/health/analysis/migrate-guest 신규 엔드포인트 추가
guest_task_id + record_id 소유권 검증 후 기존 결과를 DB에 저장
재분석 없이 즉시 반환 → OpenAI API 중복 호출 제거
Celery 결과 만료 시 404 반환 (프론트에서 재분석 fallback 처리)
dtos/analysis.py: MigrateGuestAnalysisRequest DTO 추가

<img width="1600" height="640" alt="image" src="https://github.com/user-attachments/assets/fff80781-7ea4-4cbe-a701-5f3f6347f890" />

http://localhost:8000/api/docs