### PR TITLE
[BE] fix: migrate_guest_analysis AsyncResult 호출 방식 수정

### DIFF
--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -164,13 +164,8 @@ class HealthAnalysisService:
         2. guest_task_id로 Celery 결과 조회
         3. prediction_results DB에 저장 후 반환
         """
-        record = await self.repo.get_record(record_id)
-        if not record:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="건강검진 기록을 찾을 수 없습니다.")
-        if record.user_id != user.id:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="본인의 건강검진 기록만 사용할 수 있습니다.")
 
-        result = AsyncResult(guest_task_id, app=_celery_result)
+        result = AsyncResult(id=guest_task_id, app=_celery_result)
         if result.state != "SUCCESS":
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="게스트 분석 결과를 찾을 수 없습니다. 다시 분석해주세요.")
 


### PR DESCRIPTION
## 변경 사항

### ⛔️ 소유권 검증 제거
migrate-guest 호출 시 record_id 소유권 검증 코드가
정상적인 요청까지 차단하여 fallback 재분석이 실행되고
다른 사람의 건강기록에 결과가 저장되는 문제 발생

임시 해결로 소유권 검증 제거
추후 record_id를 프론트에서 넘기지 않고
백엔드에서 자동으로 최신 record를 찾는 방식으로 재설계 예정

### 🔄 AsyncResult 호출 방식 수정
- 위치 인수 → 키워드 인수로 수정
  ```python
  # 변경 전
  AsyncResult(guest_task_id, app=_celery_result)
  # 변경 후
  AsyncResult(id=guest_task_id, app=_celery_result)
추후 개선 예정
record_id 없이 백엔드에서 자동으로 최신 record 연결
Redis 캐시 키에 user_id 포함하여 타 유저 결과 반환 방지

