### PR TITLE
[AI] fix: 나이 무관하게 잘못 표시되던 위험 요인 레이블 수정

### DIFF
--- a/ai/workers/predict.py
+++ b/ai/workers/predict.py
@@ -37,7 +37,7 @@ FACTOR_MAP = {
     'hypertension': '고혈압',        
     'high_cholesterol': '고콜레스테롤', 
     'obesity': '비만',              
-    'age_bmi': '고령·과체중',         
+    'age_bmi': '나이·체중 관리 필요',
     'cholesterol': '고콜레스테롤',
     'gluc': '고혈당',
     'bmi': '과체중',
@@ -49,12 +49,12 @@ FACTOR_MAP = {
     'pulse_pressure': '고혈압',
     'risk_class': '복합위험군',
     'bp_ratio': '고혈압',           # 추가
-    'age_hypertension': '고령+고혈압',  # 추가
-    'age_cholesterol': '고령+고콜레스테롤',  # 추가
+    'age_hypertension': '나이·혈압 관리 필요',  # 추가
+    'age_cholesterol': '나이·콜레스테롤 관리 필요',  # 추가
     'age_ap_hi': '고혈압',          # 추가
     'smoke_alco': '흡연+음주',      # 추가
     'age_active': '운동부족',       # 추가
-    'bp_bmi': '비만+고혈압',        # 추가
+    'bp_bmi': '체중·혈압 관리 필요',  # 추가
 }
 
 # 챌린지 달성 시 보정값 (의학 문헌 기반)


### PR DESCRIPTION
## ⛔️ 문제
나이와 무관하게 '고령+고콜레스테롤', '고령·과체중' 등의 레이블이 표시되는 문제
→ 젊은 사용자에게도 '고령' 표현이 노출되어 혼란 유발

## 🔄 변경 사항
| 변경 전 | 변경 후 |
|---|---|
| 고령+고콜레스테롤 | 나이·콜레스테롤 관리 필요 |
| 고령·과체중 | 나이·체중 관리 필요 |
| 고령+고혈압 | 나이·혈압 관리 필요 |
| 비만+고혈압 | 체중·혈압 관리 필요 |