### PR TITLE
[BE] feat: 챌린지 달성 후 위험도 재예측 API 추가

### DIFF
--- a/backend/app/apis/v1/analysis_routers.py
+++ b/backend/app/apis/v1/analysis_routers.py
@@ -16,6 +16,7 @@ from app.dtos.analysis import (
     MigrateGuestAnalysisRequest,
     PredictionResultListResponse,
     PredictionResultResponse,
+    RecalculateRiskRequest,
 )
 from app.models.users import User
 from app.services.analysis import HealthAnalysisService
@@ -113,6 +114,29 @@ async def migrate_guest_analysis(
 ) -> Response:
     service = HealthAnalysisService(session, redis)
     result = await service.migrate_guest_analysis(data.guest_task_id, data.record_id, user)
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@analysis_router.post(
+    "/recalculate",
+    response_model=AnalysisTaskResponse,
+    status_code=status.HTTP_200_OK,
+    summary="챌린지 달성 후 위험도 재예측",
+    description=(
+        "달성한 챌린지를 기반으로 건강 수치를 보정한 뒤 위험도를 재예측한다. "
+        "completed_challenges에 달성한 챌린지 키를 전달한다. "
+        "(smoke_7days / alco_7days / active_7days / diet_7days) "
+        "결과 조회는 GET /{task_id}/wait 엔드포인트를 사용한다."
+    ),
+)
+async def recalculate_risk_analysis(
+    data: RecalculateRiskRequest,
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+    redis: Annotated[Redis, Depends(get_redis)],
+) -> Response:
+    service = HealthAnalysisService(session, redis)
+    result = await service.request_recalculate_analysis(data.record_id, data.completed_challenges, user)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
 
 

--- a/backend/app/dtos/analysis.py
+++ b/backend/app/dtos/analysis.py
@@ -62,6 +62,18 @@ class MigrateGuestAnalysisRequest(BaseModel):
     record_id: Annotated[int, Field(description="회원 건강검진 기록 ID")]
 
 
+class RecalculateRiskRequest(BaseModel):
+    """챌린지 달성 후 위험도 재예측 요청"""
+    record_id: Annotated[int, Field(description="건강검진 기록 ID")]
+    completed_challenges: Annotated[
+        list[str],
+        Field(
+            description="달성한 챌린지 키 목록 (smoke_7days / alco_7days / active_7days / diet_7days)",
+            examples=[["smoke_7days", "active_7days"]],
+        ),
+    ]
+
+
 # ──────────────────────────────────────────────
 # Response DTOs
 # ──────────────────────────────────────────────

--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -157,6 +157,38 @@ class HealthAnalysisService:
 
         return AnalysisTaskResponse(task_id=task.id, status="pending")
 
+    async def request_recalculate_analysis(
+        self, record_id: int, completed_challenges: list[str], user: User
+    ) -> AnalysisTaskResponse:
+        """
+        챌린지 달성 후 위험도 재예측 요청.
+        1. record_id로 건강검진 기록 조회 + 소유권 검증
+        2. 건강 수치를 ml1 입력 형식으로 변환
+        3. Celery task 제출 → task_id 반환
+        결과 조회는 기존 GET /{task_id}/wait 엔드포인트를 사용한다.
+        """
+        record = await self.health_repo.get_record(record_id)
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="해당 건강검진 기록을 찾을 수 없습니다.",
+            )
+        if record.user_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="본인의 건강검진 기록만 분석할 수 있습니다.",
+            )
+
+        user_data = self._convert_record_to_ml1_input(record, user)
+
+        task = _celery_sender.send_task(
+            "ml1.recalculate_risk",
+            args=[user_data, completed_challenges, user.nickname or "사용자"],
+        )
+        logger.info("ML1 재계산 task 제출 - user_id: %d, task_id: %s", user.id, task.id)
+
+        return AnalysisTaskResponse(task_id=task.id, status="pending")
+
     async def migrate_guest_analysis(self, guest_task_id: str, record_id: int, user: User) -> AnalysisResultResponse:
         """
         게스트 분석 결과를 회원 계정으로 이전.


### PR DESCRIPTION
## 📌 작업 내용
- 챌린지 달성 후 건강 수치를 보정하여 심혈관 위험도를 재예측하는 API 추가
- 기존 `predict.py`의 `recalculate_risk` 함수와 Celery 태스크(`ml1.recalculate_risk`)가 이미 구현되어 있었으나, 호출하는 API 엔드포인트가 없어 연결

## 🔄 변경 내용
- `POST /api/v1/health/analysis/recalculate` 엔드포인트 추가
- `RecalculateRiskRequest` DTO 추가 (`record_id`, `completed_challenges`)
- `HealthAnalysisService.request_recalculate_analysis()` 서비스 메서드 추가

## 📍동작 방식
1. `record_id`로 건강검진 기록 조회 + 소유권 검증
2. 달성한 챌린지(`completed_challenges`)에 따라 수치 보정값 적용
   - `smoke_7days`: 수축기 혈압 -3, 이완기 혈압 -2
   - `alco_7days`: 수축기 혈압 -2, 이완기 혈압 -1
   - `active_7days`: 수축기 혈압 -4, 이완기 혈압 -3, BMI -0.1
   - `diet_7days`: 수축기 혈압 -3, 이완기 혈압 -2
3. Celery 태스크 제출 → `task_id` 반환
4. 결과 조회는 기존 `GET /{task_id}/wait` 엔드포인트 사용

## 💡 요청 예시

```json
POST /api/v1/health/analysis/recalculate
{
  "record_id": 1,
  "completed_challenges": ["smoke_7days", "active_7days"]
}
