### PR TITLE
[BE] feat: 챌린지 인증 응답 개선 및 친구 검색 is_requested 필드 추가

### DIFF
--- a/backend/app/apis/v1/challenge_routers.py
+++ b/backend/app/apis/v1/challenge_routers.py
@@ -186,7 +186,7 @@ async def log_daily(
     current_user: Annotated[User, Depends(get_request_user)],
 ) -> Response:
     service = ChallengeService(session)
-    log = await service.log_daily(
+    log, current_streak, is_completed = await service.log_daily(
         user_challenge_id=user_challenge_id,
         user_id=current_user.id,
         verification_type=request.verification_type,
@@ -203,6 +203,8 @@ async def log_daily(
             input_value=log.input_value,
             cv_result_id=log.cv_result_id,
             created_at=log.created_at,
+            current_streak=current_streak,
+            is_completed=is_completed,
         ).model_dump(mode="json"),
         status_code=status.HTTP_201_CREATED,
     )

--- a/backend/app/dtos/challenge.py
+++ b/backend/app/dtos/challenge.py
@@ -80,6 +80,8 @@ class ChallengeLogResponse(BaseModel):
     input_value: str | None = None
     cv_result_id: int | None = None
     created_at: datetime
+    current_streak: int
+    is_completed: bool
 
 
 class MessageResponse(BaseModel):

--- a/backend/app/dtos/social.py
+++ b/backend/app/dtos/social.py
@@ -16,6 +16,7 @@ class UserSearchResponse(BaseModel):
     profile_image: str | None
     character_stage: int
     is_friend: bool
+    is_requested: bool
 
 
 class UserSearchListResponse(BaseModel):

--- a/backend/app/repositories/social_repository.py
+++ b/backend/app/repositories/social_repository.py
@@ -94,6 +94,17 @@ class SocialRepository:
         )
         return list(result.all())
 
+    async def has_pending_request(self, requester_id: int, receiver_id: int) -> bool:
+        """내가 상대방에게 보낸 PENDING 상태 친구 요청 존재 여부 확인"""
+        result = await self._session.execute(
+            select(Friendship).where(
+                Friendship.requester_id == requester_id,
+                Friendship.receiver_id == receiver_id,
+                Friendship.status == FriendshipStatusEnum.PENDING,
+            )
+        )
+        return result.scalar_one_or_none() is not None
+
     async def is_friend(self, user_id: int, friend_id: int) -> bool:
         """friend_list에서 친구 여부 확인"""
         result = await self._session.execute(

--- a/backend/app/services/challenge_service.py
+++ b/backend/app/services/challenge_service.py
@@ -207,11 +207,13 @@ class ChallengeService:
                         user_challenge_id, total_logs, challenge.required_success_days,
                     )
 
+        is_completed = user_challenge.status == UserChallengeStatusEnum.COMPLETED
+
         logger.info(
-            "인증 완료 - user_challenge_id: %d, streak: %d",
-            user_challenge_id, new_streak,
+            "인증 완료 - user_challenge_id: %d, streak: %d, is_completed: %s",
+            user_challenge_id, new_streak, is_completed,
         )
-        return log
+        return log, new_streak, is_completed
 
     # ══════════════════════════════════════════
     # 공통 헬퍼

--- a/backend/app/services/social.py
+++ b/backend/app/services/social.py
@@ -35,6 +35,7 @@ class SocialService:
         result = []
         for user in users:
             is_friend = await self.repo.is_friend(current_user.id, user.id)
+            is_requested = await self.repo.has_pending_request(current_user.id, user.id)
             result.append(
                 UserSearchResponse(
                     id=user.id,
@@ -42,6 +43,7 @@ class SocialService:
                     profile_image=user.profile_image,
                     character_stage=user.character_stage,
                     is_friend=is_friend,
+                    is_requested=is_requested,
                 )
             )
         return UserSearchListResponse(users=result)


### PR DESCRIPTION
## 📌 작업 내용
- 챌린지 인증 API 응답에 `current_streak`, `is_completed` 필드 추가
- 친구 검색 API 응답에 `is_requested` 필드 추가하여 중복 요청 방지
- 
## 🔄 변경 내용

**챌린지 인증 응답 개선**
- `ChallengeLogResponse` DTO에 `current_streak`, `is_completed` 추가
- `log_daily` 서비스 메서드 반환값에 streak, 완료 여부 포함
- 프론트에서 인증 성공 시 달성 여부 즉시 확인 가능

**친구 요청 중복 방지**
- `UserSearchResponse` DTO에 `is_requested` 필드 추가
- `SocialRepository`에 `has_pending_request` 메서드 추가
- 검색 시 이미 요청한 유저는 `is_requested: true` 반환
- 기존에는 새로고침 후 상태 초기화되어 409 에러 반복 발생했던 문제 해결


## 💡 응답 예시

**챌린지 인증**
```json
{
  "id": 1,
  "user_challenge_id": 5,
  "log_date": "2026-04-27",
  "verification_type": "checklist",
  "created_at": "2026-04-27T10:00:00",
  "current_streak": 7,
  "is_completed": true
}
친구 검색


{
  "id": 5,
  "nickname": "조영현",
  "is_friend": false,
  "is_requested": true
}
}
