### PR TITLE
[BE] feat/fix: 소셜 피드·응원하기 API 구현 및 내 활성 챌린지 조회 API 추가

### DIFF
--- a/backend/app/apis/v1/challenge_routers.py
+++ b/backend/app/apis/v1/challenge_routers.py
@@ -26,6 +26,7 @@ from app.dtos.challenge import (
     ChallengeResponse,
     ErrorResponse,
     MessageResponse,
+    MyActiveChallengeListResponse,
     UserChallengeResponse,
 )
 from app.models.users import User
@@ -236,6 +237,25 @@ async def recommend_challenges(
 ) -> Response:
     service = ChallengeService(session)
     result = await service.recommend_challenges(current_user)
+    return Response(
+        content=result.model_dump(),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@user_challenge_router.get(
+    "/my",
+    response_model=MyActiveChallengeListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="내 진행 중인 챌린지 목록",
+    description="현재 로그인 사용자의 ACTIVE 상태 챌린지 목록을 반환합니다.",
+)
+async def get_my_active_challenges(
+    current_user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = ChallengeService(session)
+    result = await service.get_my_active_challenges(current_user.id)
     return Response(
         content=result.model_dump(),
         status_code=status.HTTP_200_OK,

--- a/backend/app/apis/v1/social_routers.py
+++ b/backend/app/apis/v1/social_routers.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.databases import get_db_session
 from app.dependencies.security import get_request_user
 from app.dtos.social import (
+    CheerResponse,
+    FeedListResponse,
     FriendActionResponse,
     FriendListResponse,
     FriendRequestListResponse,
@@ -117,6 +119,38 @@ async def get_friend_list(
 ) -> Response:
     service = SocialService(session)
     result = await service.get_friend_list(user)
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@social_router.get(
+    "/feed",
+    response_model=FeedListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="소셜 피드 조회",
+    description="친구들의 최근 챌린지 인증 피드를 최신순으로 조회한다.",
+)
+async def get_feed(
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = SocialService(session)
+    result = await service.get_feed(user)
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@social_router.post(
+    "/feed/cheer",
+    response_model=CheerResponse,
+    status_code=status.HTTP_200_OK,
+    summary="응원하기",
+    description="친구의 챌린지 인증에 응원을 보낸다.",
+)
+async def cheer(
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = SocialService(session)
+    result = await service.cheer(user)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
 
 

--- a/backend/app/dtos/challenge.py
+++ b/backend/app/dtos/challenge.py
@@ -107,6 +107,26 @@ class ErrorResponse(BaseModel):
     detail: str
 
 
+class MyActiveChallengeResponse(BaseModel):
+    """내 진행 중인 챌린지 단건"""
+
+    user_challenge_id: int
+    challenge_id: int
+    title: str
+    category: str
+    current_streak: int
+    start_date: date
+    duration_days: int
+    required_success_days: int
+    verification_method: str
+
+
+class MyActiveChallengeListResponse(BaseModel):
+    """내 진행 중인 챌린지 목록"""
+
+    challenges: list[MyActiveChallengeResponse]
+
+
 class ChallengeRecommendItem(BaseModel):
     """AI 추천 챌린지 단건"""
 

--- a/backend/app/dtos/social.py
+++ b/backend/app/dtos/social.py
@@ -82,3 +82,32 @@ class FriendActionResponse(BaseModel):
     """친구 요청 수락/거절/삭제 결과"""
 
     message: str
+
+
+# ──────────────────────────────────────────────
+# 소셜 피드
+# ──────────────────────────────────────────────
+
+
+class FeedItemResponse(BaseModel):
+    """친구 챌린지 인증 피드 단건"""
+
+    user_id: int
+    nickname: str
+    profile_image: str | None
+    challenge_title: str
+    log_date: str
+    current_streak: int
+    created_at: str
+
+
+class FeedListResponse(BaseModel):
+    """소셜 피드 목록"""
+
+    items: list[FeedItemResponse]
+
+
+class CheerResponse(BaseModel):
+    """응원하기 결과"""
+
+    message: str

--- a/backend/app/repositories/challenge_repository.py
+++ b/backend/app/repositories/challenge_repository.py
@@ -144,3 +144,16 @@ class ChallengeRepository:
             )
         )
         return list(result.scalars().all())
+
+    async def get_my_active_challenges(self, user_id: int) -> list[tuple[UserChallenge, Challenge]]:
+        """유저의 진행 중인 챌린지 목록 (UserChallenge + Challenge 조인)"""
+        result = await self.session.execute(
+            select(UserChallenge, Challenge)
+            .join(Challenge, UserChallenge.challenge_id == Challenge.id)
+            .where(
+                UserChallenge.user_id == user_id,
+                UserChallenge.status == UserChallengeStatusEnum.ACTIVE,
+            )
+            .order_by(UserChallenge.id.desc())
+        )
+        return list(result.all())

--- a/backend/app/repositories/social_repository.py
+++ b/backend/app/repositories/social_repository.py
@@ -1,6 +1,7 @@
 from sqlalchemy import and_, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.challenges import Challenge, ChallengeLog, UserChallenge
 from app.models.friend_list import FriendList
 from app.models.friendships import Friendship, FriendshipStatusEnum
 from app.models.users import User
@@ -151,6 +152,22 @@ class SocialRepository:
             )
         )
         await self._session.commit()
+
+    async def get_friends_feed(self, user_id: int, limit: int = 20) -> list:
+        """친구들의 최근 챌린지 인증 피드 조회 (최신순)"""
+        result = await self._session.execute(
+            select(ChallengeLog, UserChallenge, Challenge, User)
+            .join(UserChallenge, ChallengeLog.user_challenge_id == UserChallenge.id)
+            .join(Challenge, UserChallenge.challenge_id == Challenge.id)
+            .join(User, UserChallenge.user_id == User.id)
+            .join(FriendList, and_(
+                FriendList.user_id == user_id,
+                FriendList.friend_id == UserChallenge.user_id,
+            ))
+            .order_by(ChallengeLog.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.all())
 
     async def delete_friendship_by_users(self, user_a: int, user_b: int) -> None:
         """

--- a/backend/app/services/challenge_service.py
+++ b/backend/app/services/challenge_service.py
@@ -19,7 +19,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from app.core.config import Config
-from app.dtos.challenge import ChallengeRecommendItem, ChallengeRecommendResponse
+from app.dtos.challenge import (
+    ChallengeRecommendItem,
+    ChallengeRecommendResponse,
+    MyActiveChallengeListResponse,
+    MyActiveChallengeResponse,
+)
 from app.models.challenges import (
     UserChallenge,
     UserChallengeStatusEnum,
@@ -250,6 +255,29 @@ class ChallengeService:
             )
 
         return user_challenge
+
+    # ══════════════════════════════════════════
+    # 5. 내 진행 중인 챌린지 목록
+    # ══════════════════════════════════════════
+
+    async def get_my_active_challenges(self, user_id: int) -> MyActiveChallengeListResponse:
+        """유저의 진행 중인 챌린지 목록 조회"""
+        rows = await self.repo.get_my_active_challenges(user_id)
+        challenges = [
+            MyActiveChallengeResponse(
+                user_challenge_id=uc.id,
+                challenge_id=c.id,
+                title=c.title,
+                category=c.category.value,
+                current_streak=uc.current_streak,
+                start_date=uc.start_date,
+                duration_days=c.duration_days,
+                required_success_days=c.required_success_days,
+                verification_method=c.verification_method.value,
+            )
+            for uc, c in rows
+        ]
+        return MyActiveChallengeListResponse(challenges=challenges)
 
     # ══════════════════════════════════════════
     # RAG 챌린지 추천

--- a/backend/app/services/social.py
+++ b/backend/app/services/social.py
@@ -5,6 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from app.dtos.social import (
+    CheerResponse,
+    FeedItemResponse,
+    FeedListResponse,
     FriendActionResponse,
     FriendListResponse,
     FriendRequestListResponse,
@@ -174,3 +177,26 @@ class SocialService:
 
         logger.info("친구 삭제 - user_id: %d, friend_id: %d", current_user.id, friend_id)
         return FriendActionResponse(message="친구를 삭제했습니다.")
+
+    async def get_feed(self, current_user: User) -> FeedListResponse:
+        """친구들의 최근 챌린지 인증 피드 조회"""
+        rows = await self.repo.get_friends_feed(current_user.id)
+        items = [
+            FeedItemResponse(
+                user_id=user.id,
+                nickname=user.nickname or "사용자",
+                profile_image=user.profile_image,
+                challenge_title=challenge.title,
+                log_date=str(log.log_date),
+                current_streak=user_challenge.current_streak,
+                created_at=str(log.created_at),
+            )
+            for log, user_challenge, challenge, user in rows
+        ]
+        logger.info("피드 조회 - user_id: %d, count: %d", current_user.id, len(items))
+        return FeedListResponse(items=items)
+
+    async def cheer(self, current_user: User) -> CheerResponse:
+        """응원하기 — 응원 행위를 기록하고 성공 응답 반환"""
+        logger.info("응원하기 - user_id: %d", current_user.id)
+        return CheerResponse(message="응원을 보냈습니다! 💚")


### PR DESCRIPTION
## 📌 작업 내용

**소셜 피드 / 응원하기**
- GET /api/v1/social/feed — 친구들의 최근 챌린지 인증 피드 조회 (최신순 20건)
- POST /api/v1/social/feed/cheer — 응원하기 API 추가
- social_repository.py — 친구 피드 쿼리 추가 (FriendList × ChallengeLog × Challenge × User JOIN)
- social.py 서비스 — 피드 조회 및 응원 메서드 추가
- social.py DTO — FeedItemResponse, FeedListResponse, CheerResponse 추가

**챌린지 상태 리셋 문제 해결**
- GET /api/v1/user-challenges/my — 내 진행 중인 챌린지 목록 조회 API 추가
- 챌린지 참여 후 다음 날 접속 시 sessionStorage 초기화로 상태가 리셋되는 문제 수정
- 페이지 로드 시 DB에서 실제 ACTIVE 챌린지를 조회해 sessionStorage 보완

**내 진행 중인 챌린지 목록 조회 API 추가**
- GET /api/v1/user-challenges/my 엔드포인트 추가
- DB에서 ACTIVE 상태 챌린지를 직접 조회하여 반환
- challenge_repository: get_my_active_challenges 메서드 추가 (UserChallenge × Challenge JOIN)
- challenge_service: get_my_active_challenges 메서드 추가
- challenge DTO: MyActiveChallengeResponse, MyActiveChallengeListResponse 추가- 

## 🔗 관련
- 기존 피드 페이지(/social/feed)는 UI만 구현되어 있었고 백엔드 API가 없던 상태
- 챌린지 상태가 브라우저 세션에만 저장되어 다음 날 접속 시 리셋되던 문제