### PR TITLE
[BE] feat: 친구 응원하기 및 소셜 알림 기능 추가

### DIFF
--- a/backend/app/apis/v1/challenge_routers.py
+++ b/backend/app/apis/v1/challenge_routers.py
@@ -257,6 +257,6 @@ async def get_my_active_challenges(
     service = ChallengeService(session)
     result = await service.get_my_active_challenges(current_user.id)
     return Response(
-        content=result.model_dump(),
+        content=result.model_dump(mode="json"),
         status_code=status.HTTP_200_OK,
     )

--- a/backend/app/apis/v1/social_routers.py
+++ b/backend/app/apis/v1/social_routers.py
@@ -7,8 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.databases import get_db_session
 from app.dependencies.security import get_request_user
 from app.dtos.social import (
+    CheerRequest,
     CheerResponse,
     FeedListResponse,
+    FeedNotificationListResponse,
     FriendActionResponse,
     FriendListResponse,
     FriendRequestListResponse,
@@ -146,11 +148,28 @@ async def get_feed(
     description="친구의 챌린지 인증에 응원을 보낸다.",
 )
 async def cheer(
+    payload: CheerRequest,
     user: Annotated[User, Depends(get_request_user)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> Response:
     service = SocialService(session)
-    result = await service.cheer(user)
+    result = await service.cheer(payload, user)
+    return Response(result.model_dump(), status_code=status.HTTP_200_OK)
+
+
+@social_router.get(
+    "/feed/notifications",
+    response_model=FeedNotificationListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="피드 응원 알림 목록 조회",
+    description="현재 로그인 사용자가 받은 친구 피드 응원 알림을 최신순으로 조회한다.",
+)
+async def get_feed_notifications(
+    user: Annotated[User, Depends(get_request_user)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Response:
+    service = SocialService(session)
+    result = await service.get_feed_notifications(user)
     return Response(result.model_dump(), status_code=status.HTTP_200_OK)
 
 

--- a/backend/app/apis/v1/social_routers.py
+++ b/backend/app/apis/v1/social_routers.py
@@ -32,7 +32,9 @@ social_router = APIRouter(prefix="/social", tags=["social"])
     description="닉네임 키워드로 사용자를 검색한다. 자신은 제외되며, 각 결과에 친구 여부(is_friend)가 포함된다. 최대 20건 반환.",
 )
 async def search_users(
-    nickname: Annotated[str, Query(min_length=1, max_length=20, description="검색할 닉네임 키워드")],
+    nickname: Annotated[
+        str, Query(min_length=1, max_length=20, description="검색할 닉네임 키워드")
+    ],
     user: Annotated[User, Depends(get_request_user)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> Response:

--- a/backend/app/apis/v1/social_routers.py
+++ b/backend/app/apis/v1/social_routers.py
@@ -32,9 +32,7 @@ social_router = APIRouter(prefix="/social", tags=["social"])
     description="닉네임 키워드로 사용자를 검색한다. 자신은 제외되며, 각 결과에 친구 여부(is_friend)가 포함된다. 최대 20건 반환.",
 )
 async def search_users(
-    nickname: Annotated[
-        str, Query(min_length=1, max_length=20, description="검색할 닉네임 키워드")
-    ],
+    nickname: Annotated[str, Query(min_length=1, max_length=20, description="검색할 닉네임 키워드")],
     user: Annotated[User, Depends(get_request_user)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> Response:

--- a/backend/app/dtos/social.py
+++ b/backend/app/dtos/social.py
@@ -90,15 +90,19 @@ class FriendActionResponse(BaseModel):
 
 
 class FeedItemResponse(BaseModel):
-    """친구 챌린지 인증 피드 단건"""
+    """친구의 진행 중 챌린지 오늘 상태 단건"""
 
+    challenge_id: int
+    user_challenge_id: int
+    challenge_log_id: int | None
     user_id: int
     nickname: str
     profile_image: str | None
     challenge_title: str
-    log_date: str
+    log_date: str | None
     current_streak: int
     created_at: str
+    certified_today: bool
 
 
 class FeedListResponse(BaseModel):
@@ -111,3 +115,31 @@ class CheerResponse(BaseModel):
     """응원하기 결과"""
 
     message: str
+    notification_id: int | None = None
+
+
+class CheerRequest(BaseModel):
+    """응원하기 요청"""
+
+    target_user_id: int
+    challenge_log_id: int | None = None
+
+
+class FeedNotificationResponse(BaseModel):
+    """피드 응원 알림 단건"""
+
+    id: int
+    sender_id: int
+    sender_nickname: str
+    sender_profile_image: str | None
+    challenge_log_id: int | None
+    challenge_title: str | None
+    message: str
+    read_at: datetime | None
+    created_at: datetime
+
+
+class FeedNotificationListResponse(BaseModel):
+    """피드 응원 알림 목록"""
+
+    notifications: list[FeedNotificationResponse]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,4 +5,5 @@ from app.models.friendships import Friendship
 from app.models.health import HealthRecord
 from app.models.point_logs import PointLog
 from app.models.prediction_results import PredictionResult
+from app.models.social_notifications import SocialNotification
 from app.models.users import User

--- a/backend/app/models/social_notifications.py
+++ b/backend/app/models/social_notifications.py
@@ -14,15 +14,9 @@ class SocialNotificationTypeEnum(StrEnum):
 class SocialNotification(Base):
     __tablename__ = "social_notifications"
 
-    id: Mapped[int] = mapped_column(
-        Integer, primary_key=True, autoincrement=True, comment="소셜 알림 ID"
-    )
-    receiver_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, comment="알림 수신자"
-    )
-    sender_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("users.id"), nullable=False, comment="알림 발신자"
-    )
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True, comment="소셜 알림 ID")
+    receiver_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 수신자")
+    sender_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 발신자")
     challenge_log_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey("challenge_logs.id"),
@@ -30,19 +24,13 @@ class SocialNotification(Base):
         comment="응원 대상 챌린지 인증 로그",
     )
     type: Mapped[SocialNotificationTypeEnum] = mapped_column(
-        Enum(
-            SocialNotificationTypeEnum, values_callable=lambda x: [e.value for e in x]
-        ),
+        Enum(SocialNotificationTypeEnum, values_callable=lambda x: [e.value for e in x]),
         nullable=False,
         default=SocialNotificationTypeEnum.CHEER,
         comment="알림 유형",
     )
-    message: Mapped[str] = mapped_column(
-        String(255), nullable=False, comment="알림 메시지"
-    )
-    read_at: Mapped[datetime | None] = mapped_column(
-        DateTime, nullable=True, comment="읽은 시각"
-    )
+    message: Mapped[str] = mapped_column(String(255), nullable=False, comment="알림 메시지")
+    read_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, comment="읽은 시각")
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(), comment="알림 생성 시각"
     )

--- a/backend/app/models/social_notifications.py
+++ b/backend/app/models/social_notifications.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class SocialNotificationTypeEnum(StrEnum):
+    CHEER = "cheer"
+
+
+class SocialNotification(Base):
+    __tablename__ = "social_notifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True, comment="소셜 알림 ID")
+    receiver_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 수신자")
+    sender_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 발신자")
+    challenge_log_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("challenge_logs.id"), nullable=True, comment="응원 대상 챌린지 인증 로그"
+    )
+    type: Mapped[SocialNotificationTypeEnum] = mapped_column(
+        Enum(SocialNotificationTypeEnum, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        default=SocialNotificationTypeEnum.CHEER,
+        comment="알림 유형",
+    )
+    message: Mapped[str] = mapped_column(String(255), nullable=False, comment="알림 메시지")
+    read_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, comment="읽은 시각")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), comment="알림 생성 시각"
+    )

--- a/backend/app/models/social_notifications.py
+++ b/backend/app/models/social_notifications.py
@@ -14,20 +14,35 @@ class SocialNotificationTypeEnum(StrEnum):
 class SocialNotification(Base):
     __tablename__ = "social_notifications"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True, comment="소셜 알림 ID")
-    receiver_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 수신자")
-    sender_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False, comment="알림 발신자")
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, comment="소셜 알림 ID"
+    )
+    receiver_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=False, comment="알림 수신자"
+    )
+    sender_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=False, comment="알림 발신자"
+    )
     challenge_log_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("challenge_logs.id"), nullable=True, comment="응원 대상 챌린지 인증 로그"
+        Integer,
+        ForeignKey("challenge_logs.id"),
+        nullable=True,
+        comment="응원 대상 챌린지 인증 로그",
     )
     type: Mapped[SocialNotificationTypeEnum] = mapped_column(
-        Enum(SocialNotificationTypeEnum, values_callable=lambda x: [e.value for e in x]),
+        Enum(
+            SocialNotificationTypeEnum, values_callable=lambda x: [e.value for e in x]
+        ),
         nullable=False,
         default=SocialNotificationTypeEnum.CHEER,
         comment="알림 유형",
     )
-    message: Mapped[str] = mapped_column(String(255), nullable=False, comment="알림 메시지")
-    read_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, comment="읽은 시각")
+    message: Mapped[str] = mapped_column(
+        String(255), nullable=False, comment="알림 메시지"
+    )
+    read_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, comment="읽은 시각"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(), comment="알림 생성 시각"
     )

--- a/backend/app/repositories/social_repository.py
+++ b/backend/app/repositories/social_repository.py
@@ -28,9 +28,7 @@ class SocialRepository:
         # 외부에서 주입받은 DB 세션 (FastAPI의 Depends를 통해 전달됨)
         self._session = session
 
-    async def search_users_by_nickname(
-        self, keyword: str, exclude_user_id: int
-    ) -> list[User]:
+    async def search_users_by_nickname(self, keyword: str, exclude_user_id: int) -> list[User]:
         """
         닉네임 키워드로 사용자 검색 (부분 일치, 자신 제외, 탈퇴 계정 제외).
         최대 20건 반환.
@@ -77,9 +75,7 @@ class SocialRepository:
         )
         return result.scalar_one_or_none()
 
-    async def create_friendship(
-        self, requester_id: int, receiver_id: int
-    ) -> Friendship:
+    async def create_friendship(self, requester_id: int, receiver_id: int) -> Friendship:
         """
         친구 요청 생성 (PENDING 상태).
         commit 후 refresh하여 DB에서 자동 생성된 값(id, created_at 등)을 반영한다.
@@ -99,14 +95,10 @@ class SocialRepository:
         친구 요청 ID(PK)로 단건 조회.
         없으면 None 반환.
         """
-        result = await self._session.execute(
-            select(Friendship).where(Friendship.id == request_id)
-        )
+        result = await self._session.execute(select(Friendship).where(Friendship.id == request_id))
         return result.scalar_one_or_none()
 
-    async def update_friendship_status(
-        self, friendship: Friendship, new_status: FriendshipStatusEnum
-    ) -> None:
+    async def update_friendship_status(self, friendship: Friendship, new_status: FriendshipStatusEnum) -> None:
         """친구 요청 상태 변경 (PENDING → ACCEPTED / REJECTED 등)"""
         friendship.status = new_status
         await self._session.commit()
@@ -181,20 +173,14 @@ class SocialRepository:
         await self._session.execute(
             delete(FriendList).where(
                 or_(
-                    and_(
-                        FriendList.user_id == user_id, FriendList.friend_id == friend_id
-                    ),
-                    and_(
-                        FriendList.user_id == friend_id, FriendList.friend_id == user_id
-                    ),
+                    and_(FriendList.user_id == user_id, FriendList.friend_id == friend_id),
+                    and_(FriendList.user_id == friend_id, FriendList.friend_id == user_id),
                 )
             )
         )
         await self._session.commit()
 
-    async def get_friends_feed(
-        self, user_id: int, target_date: date, limit: int = 50
-    ) -> list:
+    async def get_friends_feed(self, user_id: int, target_date: date, limit: int = 50) -> list:
         """친구들의 진행 중 챌린지와 오늘 인증 여부 조회"""
         result = await self._session.execute(
             select(UserChallenge, Challenge, User, ChallengeLog)

--- a/backend/app/repositories/social_repository.py
+++ b/backend/app/repositories/social_repository.py
@@ -3,10 +3,18 @@ from datetime import date
 from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.challenges import Challenge, ChallengeLog, UserChallenge, UserChallengeStatusEnum
+from app.models.challenges import (
+    Challenge,
+    ChallengeLog,
+    UserChallenge,
+    UserChallengeStatusEnum,
+)
 from app.models.friend_list import FriendList
 from app.models.friendships import Friendship, FriendshipStatusEnum
-from app.models.social_notifications import SocialNotification, SocialNotificationTypeEnum
+from app.models.social_notifications import (
+    SocialNotification,
+    SocialNotificationTypeEnum,
+)
 from app.models.users import User
 
 
@@ -20,7 +28,9 @@ class SocialRepository:
         # 외부에서 주입받은 DB 세션 (FastAPI의 Depends를 통해 전달됨)
         self._session = session
 
-    async def search_users_by_nickname(self, keyword: str, exclude_user_id: int) -> list[User]:
+    async def search_users_by_nickname(
+        self, keyword: str, exclude_user_id: int
+    ) -> list[User]:
         """
         닉네임 키워드로 사용자 검색 (부분 일치, 자신 제외, 탈퇴 계정 제외).
         최대 20건 반환.
@@ -44,8 +54,14 @@ class SocialRepository:
         result = await self._session.execute(
             select(Friendship).where(
                 or_(
-                    and_(Friendship.requester_id == user_a, Friendship.receiver_id == user_b),
-                    and_(Friendship.requester_id == user_b, Friendship.receiver_id == user_a),
+                    and_(
+                        Friendship.requester_id == user_a,
+                        Friendship.receiver_id == user_b,
+                    ),
+                    and_(
+                        Friendship.requester_id == user_b,
+                        Friendship.receiver_id == user_a,
+                    ),
                 )
             )
         )
@@ -61,7 +77,9 @@ class SocialRepository:
         )
         return result.scalar_one_or_none()
 
-    async def create_friendship(self, requester_id: int, receiver_id: int) -> Friendship:
+    async def create_friendship(
+        self, requester_id: int, receiver_id: int
+    ) -> Friendship:
         """
         친구 요청 생성 (PENDING 상태).
         commit 후 refresh하여 DB에서 자동 생성된 값(id, created_at 등)을 반영한다.
@@ -81,10 +99,14 @@ class SocialRepository:
         친구 요청 ID(PK)로 단건 조회.
         없으면 None 반환.
         """
-        result = await self._session.execute(select(Friendship).where(Friendship.id == request_id))
+        result = await self._session.execute(
+            select(Friendship).where(Friendship.id == request_id)
+        )
         return result.scalar_one_or_none()
 
-    async def update_friendship_status(self, friendship: Friendship, new_status: FriendshipStatusEnum) -> None:
+    async def update_friendship_status(
+        self, friendship: Friendship, new_status: FriendshipStatusEnum
+    ) -> None:
         """친구 요청 상태 변경 (PENDING → ACCEPTED / REJECTED 등)"""
         friendship.status = new_status
         await self._session.commit()
@@ -159,14 +181,20 @@ class SocialRepository:
         await self._session.execute(
             delete(FriendList).where(
                 or_(
-                    and_(FriendList.user_id == user_id, FriendList.friend_id == friend_id),
-                    and_(FriendList.user_id == friend_id, FriendList.friend_id == user_id),
+                    and_(
+                        FriendList.user_id == user_id, FriendList.friend_id == friend_id
+                    ),
+                    and_(
+                        FriendList.user_id == friend_id, FriendList.friend_id == user_id
+                    ),
                 )
             )
         )
         await self._session.commit()
 
-    async def get_friends_feed(self, user_id: int, target_date: date, limit: int = 50) -> list:
+    async def get_friends_feed(
+        self, user_id: int, target_date: date, limit: int = 50
+    ) -> list:
         """친구들의 진행 중 챌린지와 오늘 인증 여부 조회"""
         result = await self._session.execute(
             select(UserChallenge, Challenge, User, ChallengeLog)
@@ -233,12 +261,14 @@ class SocialRepository:
     ) -> SocialNotification | None:
         """같은 친구에게 같은 날짜에 보낸 응원 알림 조회"""
         result = await self._session.execute(
-            select(SocialNotification).where(
+            select(SocialNotification)
+            .where(
                 SocialNotification.receiver_id == receiver_id,
                 SocialNotification.sender_id == sender_id,
                 SocialNotification.type == SocialNotificationTypeEnum.CHEER,
                 func.date(SocialNotification.created_at) == target_date,
-            ).order_by(SocialNotification.created_at.desc())
+            )
+            .order_by(SocialNotification.created_at.desc())
         )
         return result.scalars().first()
 
@@ -247,8 +277,16 @@ class SocialRepository:
         result = await self._session.execute(
             select(SocialNotification, User, Challenge)
             .join(User, SocialNotification.sender_id == User.id)
-            .join(ChallengeLog, SocialNotification.challenge_log_id == ChallengeLog.id, isouter=True)
-            .join(UserChallenge, ChallengeLog.user_challenge_id == UserChallenge.id, isouter=True)
+            .join(
+                ChallengeLog,
+                SocialNotification.challenge_log_id == ChallengeLog.id,
+                isouter=True,
+            )
+            .join(
+                UserChallenge,
+                ChallengeLog.user_challenge_id == UserChallenge.id,
+                isouter=True,
+            )
             .join(Challenge, UserChallenge.challenge_id == Challenge.id, isouter=True)
             .where(SocialNotification.receiver_id == user_id)
             .order_by(SocialNotification.created_at.desc())
@@ -264,8 +302,14 @@ class SocialRepository:
         await self._session.execute(
             delete(Friendship).where(
                 or_(
-                    and_(Friendship.requester_id == user_a, Friendship.receiver_id == user_b),
-                    and_(Friendship.requester_id == user_b, Friendship.receiver_id == user_a),
+                    and_(
+                        Friendship.requester_id == user_a,
+                        Friendship.receiver_id == user_b,
+                    ),
+                    and_(
+                        Friendship.requester_id == user_b,
+                        Friendship.receiver_id == user_a,
+                    ),
                 )
             )
         )

--- a/backend/app/repositories/social_repository.py
+++ b/backend/app/repositories/social_repository.py
@@ -1,9 +1,12 @@
-from sqlalchemy import and_, delete, or_, select
+from datetime import date
+
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.challenges import Challenge, ChallengeLog, UserChallenge
+from app.models.challenges import Challenge, ChallengeLog, UserChallenge, UserChallengeStatusEnum
 from app.models.friend_list import FriendList
 from app.models.friendships import Friendship, FriendshipStatusEnum
+from app.models.social_notifications import SocialNotification, SocialNotificationTypeEnum
 from app.models.users import User
 
 
@@ -44,6 +47,16 @@ class SocialRepository:
                     and_(Friendship.requester_id == user_a, Friendship.receiver_id == user_b),
                     and_(Friendship.requester_id == user_b, Friendship.receiver_id == user_a),
                 )
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_user_by_id(self, user_id: int) -> User | None:
+        """탈퇴하지 않은 사용자 단건 조회"""
+        result = await self._session.execute(
+            select(User).where(
+                User.id == user_id,
+                User.is_deleted == False,  # noqa: E712
             )
         )
         return result.scalar_one_or_none()
@@ -153,13 +166,20 @@ class SocialRepository:
         )
         await self._session.commit()
 
-    async def get_friends_feed(self, user_id: int, limit: int = 20) -> list:
-        """친구들의 최근 챌린지 인증 피드 조회 (최신순)"""
+    async def get_friends_feed(self, user_id: int, target_date: date, limit: int = 50) -> list:
+        """친구들의 진행 중 챌린지와 오늘 인증 여부 조회"""
         result = await self._session.execute(
-            select(ChallengeLog, UserChallenge, Challenge, User)
-            .join(UserChallenge, ChallengeLog.user_challenge_id == UserChallenge.id)
+            select(UserChallenge, Challenge, User, ChallengeLog)
             .join(Challenge, UserChallenge.challenge_id == Challenge.id)
             .join(User, UserChallenge.user_id == User.id)
+            .join(
+                ChallengeLog,
+                and_(
+                    ChallengeLog.user_challenge_id == UserChallenge.id,
+                    ChallengeLog.log_date == target_date,
+                ),
+                isouter=True,
+            )
             .join(
                 FriendList,
                 and_(
@@ -167,7 +187,71 @@ class SocialRepository:
                     FriendList.friend_id == UserChallenge.user_id,
                 ),
             )
-            .order_by(ChallengeLog.created_at.desc())
+            .where(UserChallenge.status == UserChallengeStatusEnum.ACTIVE)
+            .order_by(ChallengeLog.created_at.desc(), UserChallenge.start_date.desc())
+            .limit(limit)
+        )
+        return list(result.all())
+
+    async def get_feed_log_detail(self, challenge_log_id: int):
+        """챌린지 인증 로그와 작성자 정보를 조회한다."""
+        result = await self._session.execute(
+            select(ChallengeLog, UserChallenge, Challenge, User)
+            .join(UserChallenge, ChallengeLog.user_challenge_id == UserChallenge.id)
+            .join(Challenge, UserChallenge.challenge_id == Challenge.id)
+            .join(User, UserChallenge.user_id == User.id)
+            .where(ChallengeLog.id == challenge_log_id)
+        )
+        return result.one_or_none()
+
+    async def create_cheer_notification(
+        self,
+        receiver_id: int,
+        sender_id: int,
+        challenge_log_id: int | None,
+        message: str,
+    ) -> SocialNotification:
+        """응원 알림을 생성한다."""
+        notification = SocialNotification(
+            receiver_id=receiver_id,
+            sender_id=sender_id,
+            challenge_log_id=challenge_log_id,
+            type=SocialNotificationTypeEnum.CHEER,
+            message=message,
+        )
+        self._session.add(notification)
+
+        await self._session.commit()
+        await self._session.refresh(notification)
+        return notification
+
+    async def get_daily_cheer_notification(
+        self,
+        receiver_id: int,
+        sender_id: int,
+        target_date: date,
+    ) -> SocialNotification | None:
+        """같은 친구에게 같은 날짜에 보낸 응원 알림 조회"""
+        result = await self._session.execute(
+            select(SocialNotification).where(
+                SocialNotification.receiver_id == receiver_id,
+                SocialNotification.sender_id == sender_id,
+                SocialNotification.type == SocialNotificationTypeEnum.CHEER,
+                func.date(SocialNotification.created_at) == target_date,
+            ).order_by(SocialNotification.created_at.desc())
+        )
+        return result.scalars().first()
+
+    async def get_feed_notifications(self, user_id: int, limit: int = 20) -> list:
+        """내가 받은 피드 응원 알림 목록을 조회한다."""
+        result = await self._session.execute(
+            select(SocialNotification, User, Challenge)
+            .join(User, SocialNotification.sender_id == User.id)
+            .join(ChallengeLog, SocialNotification.challenge_log_id == ChallengeLog.id, isouter=True)
+            .join(UserChallenge, ChallengeLog.user_challenge_id == UserChallenge.id, isouter=True)
+            .join(Challenge, UserChallenge.challenge_id == Challenge.id, isouter=True)
+            .where(SocialNotification.receiver_id == user_id)
+            .order_by(SocialNotification.created_at.desc())
             .limit(limit)
         )
         return list(result.all())

--- a/backend/app/services/social.py
+++ b/backend/app/services/social.py
@@ -1,13 +1,18 @@
 import logging
+from datetime import datetime
 
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
+from app.core import config
 from app.dtos.social import (
+    CheerRequest,
     CheerResponse,
     FeedItemResponse,
     FeedListResponse,
+    FeedNotificationListResponse,
+    FeedNotificationResponse,
     FriendActionResponse,
     FriendListResponse,
     FriendRequestListResponse,
@@ -179,24 +184,110 @@ class SocialService:
         return FriendActionResponse(message="친구를 삭제했습니다.")
 
     async def get_feed(self, current_user: User) -> FeedListResponse:
-        """친구들의 최근 챌린지 인증 피드 조회"""
-        rows = await self.repo.get_friends_feed(current_user.id)
+        """친구들의 진행 중 챌린지와 오늘 인증 여부 조회"""
+        today = datetime.now(config.TIMEZONE).date()
+        rows = await self.repo.get_friends_feed(current_user.id, today)
         items = [
             FeedItemResponse(
+                challenge_id=challenge.id,
+                user_challenge_id=user_challenge.id,
+                challenge_log_id=log.id if log else None,
                 user_id=user.id,
                 nickname=user.nickname or "사용자",
                 profile_image=user.profile_image,
                 challenge_title=challenge.title,
-                log_date=str(log.log_date),
+                log_date=str(log.log_date) if log else None,
                 current_streak=user_challenge.current_streak,
-                created_at=str(log.created_at),
+                created_at=str(log.created_at) if log else str(user_challenge.start_date),
+                certified_today=log is not None,
             )
-            for log, user_challenge, challenge, user in rows
+            for user_challenge, challenge, user, log in rows
         ]
         logger.info("피드 조회 - user_id: %d, count: %d", current_user.id, len(items))
         return FeedListResponse(items=items)
 
-    async def cheer(self, current_user: User) -> CheerResponse:
-        """응원하기 — 응원 행위를 기록하고 성공 응답 반환"""
-        logger.info("응원하기 - user_id: %d", current_user.id)
-        return CheerResponse(message="응원을 보냈습니다! 💚")
+    async def cheer(self, payload: CheerRequest, current_user: User) -> CheerResponse:
+        """친구의 하루를 응원하고 하루 1회 알림을 생성한다."""
+        sender_id = current_user.id
+        sender_nickname = current_user.nickname
+        receiver_id = payload.target_user_id
+
+        if receiver_id == sender_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="나 자신에게는 응원을 보낼 수 없습니다.",
+            )
+
+        if not await self.repo.is_friend(sender_id, receiver_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="친구에게만 응원을 보낼 수 있습니다.",
+            )
+
+        receiver = await self.repo.get_user_by_id(receiver_id)
+        if not receiver:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="응원을 받을 사용자를 찾을 수 없습니다.",
+            )
+
+        challenge_log_id = payload.challenge_log_id
+        if challenge_log_id is not None:
+            row = await self.repo.get_feed_log_detail(challenge_log_id)
+            if not row:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="응원할 챌린지 인증을 찾을 수 없습니다.",
+                )
+
+            log, _user_challenge, _challenge, log_owner = row
+            if log_owner.id != receiver_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="응원 대상 사용자와 챌린지 인증 작성자가 일치하지 않습니다.",
+                )
+            challenge_log_id = log.id
+
+        existing = await self.repo.get_daily_cheer_notification(
+            receiver_id=receiver_id,
+            sender_id=sender_id,
+            target_date=datetime.now(config.TIMEZONE).date(),
+        )
+        if existing:
+            return CheerResponse(message="오늘은 이미 이 친구에게 응원을 보냈어요.", notification_id=existing.id)
+
+        message = f"{sender_nickname}님이 오늘의 응원을 보냈어요."
+        notification = await self.repo.create_cheer_notification(
+            receiver_id=receiver_id,
+            sender_id=sender_id,
+            challenge_log_id=challenge_log_id,
+            message=message,
+        )
+
+        logger.info(
+            "응원하기 - sender_id: %d, receiver_id: %d, challenge_log_id: %d",
+            sender_id,
+            receiver_id,
+            challenge_log_id or 0,
+        )
+        return CheerResponse(message="오늘의 응원을 보냈습니다! 💚", notification_id=notification.id)
+
+    async def get_feed_notifications(self, current_user: User) -> FeedNotificationListResponse:
+        """내가 받은 피드 응원 알림 목록 조회"""
+        rows = await self.repo.get_feed_notifications(current_user.id)
+        notifications = [
+            FeedNotificationResponse(
+                id=notification.id,
+                sender_id=sender.id,
+                sender_nickname=sender.nickname,
+                sender_profile_image=sender.profile_image,
+                challenge_log_id=notification.challenge_log_id,
+                challenge_title=challenge.title if challenge else None,
+                message=notification.message,
+                read_at=notification.read_at,
+                created_at=notification.created_at,
+            )
+            for notification, sender, challenge in rows
+        ]
+        logger.info("피드 응원 알림 조회 - user_id: %d, count: %d", current_user.id, len(notifications))
+        return FeedNotificationListResponse(notifications=notifications)

--- a/backend/app/services/social.py
+++ b/backend/app/services/social.py
@@ -35,9 +35,7 @@ class SocialService:
     def __init__(self, session: AsyncSession):
         self.repo = SocialRepository(session)
 
-    async def search_users(
-        self, keyword: str, current_user: User
-    ) -> UserSearchListResponse:
+    async def search_users(self, keyword: str, current_user: User) -> UserSearchListResponse:
         """닉네임 키워드로 사용자 검색 (is_friend 여부 포함)"""
         users = await self.repo.search_users_by_nickname(keyword, current_user.id)
         logger.info("사용자 검색 - keyword: %s, 결과 수: %d", keyword, len(users))
@@ -58,9 +56,7 @@ class SocialService:
             )
         return UserSearchListResponse(users=result)
 
-    async def send_friend_request(
-        self, receiver_id: int, current_user: User
-    ) -> FriendRequestSentResponse:
+    async def send_friend_request(self, receiver_id: int, current_user: User) -> FriendRequestSentResponse:
         """친구 요청 전송"""
         # 자기 자신에게 요청 불가
         if receiver_id == current_user.id:
@@ -91,17 +87,13 @@ class SocialService:
                 )
             if existing.status == FriendshipStatusEnum.REJECTED:
                 # 거절된 요청은 재요청 허용 (PENDING으로 복구)
-                await self.repo.update_friendship_status(
-                    existing, FriendshipStatusEnum.PENDING
-                )
+                await self.repo.update_friendship_status(existing, FriendshipStatusEnum.PENDING)
                 logger.info(
                     "친구 요청 재전송 - requester: %d → receiver: %d",
                     current_user.id,
                     receiver_id,
                 )
-                return FriendRequestSentResponse(
-                    request_id=existing.id, message="친구 요청을 전송했습니다."
-                )
+                return FriendRequestSentResponse(request_id=existing.id, message="친구 요청을 전송했습니다.")
 
         friendship = await self.repo.create_friendship(current_user.id, receiver_id)
         logger.info(
@@ -109,18 +101,12 @@ class SocialService:
             current_user.id,
             receiver_id,
         )
-        return FriendRequestSentResponse(
-            request_id=friendship.id, message="친구 요청을 전송했습니다."
-        )
+        return FriendRequestSentResponse(request_id=friendship.id, message="친구 요청을 전송했습니다.")
 
-    async def get_pending_requests(
-        self, current_user: User
-    ) -> FriendRequestListResponse:
+    async def get_pending_requests(self, current_user: User) -> FriendRequestListResponse:
         """받은 친구 요청 목록 조회 (PENDING 상태만)"""
         rows = await self.repo.get_pending_requests(current_user.id)
-        logger.info(
-            "친구 요청 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows)
-        )
+        logger.info("친구 요청 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows))
 
         requests = [
             FriendRequestResponse(
@@ -154,44 +140,30 @@ class SocialService:
             )
         return friendship
 
-    async def accept_friend_request(
-        self, request_id: int, current_user: User
-    ) -> FriendActionResponse:
+    async def accept_friend_request(self, request_id: int, current_user: User) -> FriendActionResponse:
         """친구 요청 수락 (FriendList 양방향 추가)"""
         friendship = await self._get_request_for_receiver(request_id, current_user)
 
-        await self.repo.update_friendship_status(
-            friendship, FriendshipStatusEnum.ACCEPTED
-        )
+        await self.repo.update_friendship_status(friendship, FriendshipStatusEnum.ACCEPTED)
         # 양방향 friend_list 추가 (A→B, B→A)
-        await self.repo.create_friend_entry(
-            friendship.requester_id, friendship.receiver_id
-        )
-        await self.repo.create_friend_entry(
-            friendship.receiver_id, friendship.requester_id
-        )
+        await self.repo.create_friend_entry(friendship.requester_id, friendship.receiver_id)
+        await self.repo.create_friend_entry(friendship.receiver_id, friendship.requester_id)
 
         logger.info("친구 요청 수락 - request_id: %d", request_id)
         return FriendActionResponse(message="친구 요청을 수락했습니다.")
 
-    async def reject_friend_request(
-        self, request_id: int, current_user: User
-    ) -> FriendActionResponse:
+    async def reject_friend_request(self, request_id: int, current_user: User) -> FriendActionResponse:
         """친구 요청 거절"""
         friendship = await self._get_request_for_receiver(request_id, current_user)
 
-        await self.repo.update_friendship_status(
-            friendship, FriendshipStatusEnum.REJECTED
-        )
+        await self.repo.update_friendship_status(friendship, FriendshipStatusEnum.REJECTED)
         logger.info("친구 요청 거절 - request_id: %d", request_id)
         return FriendActionResponse(message="친구 요청을 거절했습니다.")
 
     async def get_friend_list(self, current_user: User) -> FriendListResponse:
         """친구 목록 조회"""
         rows = await self.repo.get_friend_list(current_user.id)
-        logger.info(
-            "친구 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows)
-        )
+        logger.info("친구 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows))
 
         friends = [
             FriendResponse(
@@ -205,9 +177,7 @@ class SocialService:
         ]
         return FriendListResponse(friends=friends)
 
-    async def delete_friend(
-        self, friend_id: int, current_user: User
-    ) -> FriendActionResponse:
+    async def delete_friend(self, friend_id: int, current_user: User) -> FriendActionResponse:
         """친구 삭제 (양방향 FriendList 삭제 + Friendship 레코드 삭제로 재요청 허용)"""
         if not await self.repo.is_friend(current_user.id, friend_id):
             raise HTTPException(
@@ -218,9 +188,7 @@ class SocialService:
         await self.repo.delete_friend(current_user.id, friend_id)
         await self.repo.delete_friendship_by_users(current_user.id, friend_id)
 
-        logger.info(
-            "친구 삭제 - user_id: %d, friend_id: %d", current_user.id, friend_id
-        )
+        logger.info("친구 삭제 - user_id: %d, friend_id: %d", current_user.id, friend_id)
         return FriendActionResponse(message="친구를 삭제했습니다.")
 
     async def get_feed(self, current_user: User) -> FeedListResponse:
@@ -238,9 +206,7 @@ class SocialService:
                 challenge_title=challenge.title,
                 log_date=str(log.log_date) if log else None,
                 current_streak=user_challenge.current_streak,
-                created_at=(
-                    str(log.created_at) if log else str(user_challenge.start_date)
-                ),
+                created_at=(str(log.created_at) if log else str(user_challenge.start_date)),
                 certified_today=log is not None,
             )
             for user_challenge, challenge, user, log in rows
@@ -315,13 +281,9 @@ class SocialService:
             receiver_id,
             challenge_log_id or 0,
         )
-        return CheerResponse(
-            message="오늘의 응원을 보냈습니다! 💚", notification_id=notification.id
-        )
+        return CheerResponse(message="오늘의 응원을 보냈습니다! 💚", notification_id=notification.id)
 
-    async def get_feed_notifications(
-        self, current_user: User
-    ) -> FeedNotificationListResponse:
+    async def get_feed_notifications(self, current_user: User) -> FeedNotificationListResponse:
         """내가 받은 피드 응원 알림 목록 조회"""
         rows = await self.repo.get_feed_notifications(current_user.id)
         notifications = [

--- a/backend/app/services/social.py
+++ b/backend/app/services/social.py
@@ -35,7 +35,9 @@ class SocialService:
     def __init__(self, session: AsyncSession):
         self.repo = SocialRepository(session)
 
-    async def search_users(self, keyword: str, current_user: User) -> UserSearchListResponse:
+    async def search_users(
+        self, keyword: str, current_user: User
+    ) -> UserSearchListResponse:
         """닉네임 키워드로 사용자 검색 (is_friend 여부 포함)"""
         users = await self.repo.search_users_by_nickname(keyword, current_user.id)
         logger.info("사용자 검색 - keyword: %s, 결과 수: %d", keyword, len(users))
@@ -56,7 +58,9 @@ class SocialService:
             )
         return UserSearchListResponse(users=result)
 
-    async def send_friend_request(self, receiver_id: int, current_user: User) -> FriendRequestSentResponse:
+    async def send_friend_request(
+        self, receiver_id: int, current_user: User
+    ) -> FriendRequestSentResponse:
         """친구 요청 전송"""
         # 자기 자신에게 요청 불가
         if receiver_id == current_user.id:
@@ -87,18 +91,36 @@ class SocialService:
                 )
             if existing.status == FriendshipStatusEnum.REJECTED:
                 # 거절된 요청은 재요청 허용 (PENDING으로 복구)
-                await self.repo.update_friendship_status(existing, FriendshipStatusEnum.PENDING)
-                logger.info("친구 요청 재전송 - requester: %d → receiver: %d", current_user.id, receiver_id)
-                return FriendRequestSentResponse(request_id=existing.id, message="친구 요청을 전송했습니다.")
+                await self.repo.update_friendship_status(
+                    existing, FriendshipStatusEnum.PENDING
+                )
+                logger.info(
+                    "친구 요청 재전송 - requester: %d → receiver: %d",
+                    current_user.id,
+                    receiver_id,
+                )
+                return FriendRequestSentResponse(
+                    request_id=existing.id, message="친구 요청을 전송했습니다."
+                )
 
         friendship = await self.repo.create_friendship(current_user.id, receiver_id)
-        logger.info("친구 요청 전송 - requester: %d → receiver: %d", current_user.id, receiver_id)
-        return FriendRequestSentResponse(request_id=friendship.id, message="친구 요청을 전송했습니다.")
+        logger.info(
+            "친구 요청 전송 - requester: %d → receiver: %d",
+            current_user.id,
+            receiver_id,
+        )
+        return FriendRequestSentResponse(
+            request_id=friendship.id, message="친구 요청을 전송했습니다."
+        )
 
-    async def get_pending_requests(self, current_user: User) -> FriendRequestListResponse:
+    async def get_pending_requests(
+        self, current_user: User
+    ) -> FriendRequestListResponse:
         """받은 친구 요청 목록 조회 (PENDING 상태만)"""
         rows = await self.repo.get_pending_requests(current_user.id)
-        logger.info("친구 요청 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows))
+        logger.info(
+            "친구 요청 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows)
+        )
 
         requests = [
             FriendRequestResponse(
@@ -132,30 +154,44 @@ class SocialService:
             )
         return friendship
 
-    async def accept_friend_request(self, request_id: int, current_user: User) -> FriendActionResponse:
+    async def accept_friend_request(
+        self, request_id: int, current_user: User
+    ) -> FriendActionResponse:
         """친구 요청 수락 (FriendList 양방향 추가)"""
         friendship = await self._get_request_for_receiver(request_id, current_user)
 
-        await self.repo.update_friendship_status(friendship, FriendshipStatusEnum.ACCEPTED)
+        await self.repo.update_friendship_status(
+            friendship, FriendshipStatusEnum.ACCEPTED
+        )
         # 양방향 friend_list 추가 (A→B, B→A)
-        await self.repo.create_friend_entry(friendship.requester_id, friendship.receiver_id)
-        await self.repo.create_friend_entry(friendship.receiver_id, friendship.requester_id)
+        await self.repo.create_friend_entry(
+            friendship.requester_id, friendship.receiver_id
+        )
+        await self.repo.create_friend_entry(
+            friendship.receiver_id, friendship.requester_id
+        )
 
         logger.info("친구 요청 수락 - request_id: %d", request_id)
         return FriendActionResponse(message="친구 요청을 수락했습니다.")
 
-    async def reject_friend_request(self, request_id: int, current_user: User) -> FriendActionResponse:
+    async def reject_friend_request(
+        self, request_id: int, current_user: User
+    ) -> FriendActionResponse:
         """친구 요청 거절"""
         friendship = await self._get_request_for_receiver(request_id, current_user)
 
-        await self.repo.update_friendship_status(friendship, FriendshipStatusEnum.REJECTED)
+        await self.repo.update_friendship_status(
+            friendship, FriendshipStatusEnum.REJECTED
+        )
         logger.info("친구 요청 거절 - request_id: %d", request_id)
         return FriendActionResponse(message="친구 요청을 거절했습니다.")
 
     async def get_friend_list(self, current_user: User) -> FriendListResponse:
         """친구 목록 조회"""
         rows = await self.repo.get_friend_list(current_user.id)
-        logger.info("친구 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows))
+        logger.info(
+            "친구 목록 조회 - user_id: %d, count: %d", current_user.id, len(rows)
+        )
 
         friends = [
             FriendResponse(
@@ -169,7 +205,9 @@ class SocialService:
         ]
         return FriendListResponse(friends=friends)
 
-    async def delete_friend(self, friend_id: int, current_user: User) -> FriendActionResponse:
+    async def delete_friend(
+        self, friend_id: int, current_user: User
+    ) -> FriendActionResponse:
         """친구 삭제 (양방향 FriendList 삭제 + Friendship 레코드 삭제로 재요청 허용)"""
         if not await self.repo.is_friend(current_user.id, friend_id):
             raise HTTPException(
@@ -180,7 +218,9 @@ class SocialService:
         await self.repo.delete_friend(current_user.id, friend_id)
         await self.repo.delete_friendship_by_users(current_user.id, friend_id)
 
-        logger.info("친구 삭제 - user_id: %d, friend_id: %d", current_user.id, friend_id)
+        logger.info(
+            "친구 삭제 - user_id: %d, friend_id: %d", current_user.id, friend_id
+        )
         return FriendActionResponse(message="친구를 삭제했습니다.")
 
     async def get_feed(self, current_user: User) -> FeedListResponse:
@@ -198,7 +238,9 @@ class SocialService:
                 challenge_title=challenge.title,
                 log_date=str(log.log_date) if log else None,
                 current_streak=user_challenge.current_streak,
-                created_at=str(log.created_at) if log else str(user_challenge.start_date),
+                created_at=(
+                    str(log.created_at) if log else str(user_challenge.start_date)
+                ),
                 certified_today=log is not None,
             )
             for user_challenge, challenge, user, log in rows
@@ -254,7 +296,10 @@ class SocialService:
             target_date=datetime.now(config.TIMEZONE).date(),
         )
         if existing:
-            return CheerResponse(message="오늘은 이미 이 친구에게 응원을 보냈어요.", notification_id=existing.id)
+            return CheerResponse(
+                message="오늘은 이미 이 친구에게 응원을 보냈어요.",
+                notification_id=existing.id,
+            )
 
         message = f"{sender_nickname}님이 오늘의 응원을 보냈어요."
         notification = await self.repo.create_cheer_notification(
@@ -270,9 +315,13 @@ class SocialService:
             receiver_id,
             challenge_log_id or 0,
         )
-        return CheerResponse(message="오늘의 응원을 보냈습니다! 💚", notification_id=notification.id)
+        return CheerResponse(
+            message="오늘의 응원을 보냈습니다! 💚", notification_id=notification.id
+        )
 
-    async def get_feed_notifications(self, current_user: User) -> FeedNotificationListResponse:
+    async def get_feed_notifications(
+        self, current_user: User
+    ) -> FeedNotificationListResponse:
         """내가 받은 피드 응원 알림 목록 조회"""
         rows = await self.repo.get_feed_notifications(current_user.id)
         notifications = [
@@ -289,5 +338,9 @@ class SocialService:
             )
             for notification, sender, challenge in rows
         ]
-        logger.info("피드 응원 알림 조회 - user_id: %d, count: %d", current_user.id, len(notifications))
+        logger.info(
+            "피드 응원 알림 조회 - user_id: %d, count: %d",
+            current_user.id,
+            len(notifications),
+        )
         return FeedNotificationListResponse(notifications=notifications)

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,6 +4,7 @@ upstream fastapi {
 
 server {
     server_name 13.125.247.40;
+    client_max_body_size 20M;
 
     listen 80;
 

--- a/nginx/prod_http.conf
+++ b/nginx/prod_http.conf
@@ -4,6 +4,7 @@ upstream fastapi {
 
 server {
     server_name 54.180.116.239;
+    client_max_body_size 20M;
 
     listen 80;
 

--- a/nginx/prod_https.conf
+++ b/nginx/prod_https.conf
@@ -6,6 +6,7 @@ upstream fastapi {
 server {
     listen 80;
     server_name myhealthbuddy.duckdns.org;
+    client_max_body_size 20M;
 
     # 추후 certbot ssl 인증서 갱신 시 필요
     location /.well-known/acme-challenge/ {
@@ -24,6 +25,7 @@ server {
 # https
 server {
     server_name myhealthbuddy.duckdns.org;
+    client_max_body_size 20M;
 
     listen 443 ssl;
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>친구 응원하기 &amp; 소셜 알림 기능 추가</h1>
<hr>
<h2>📌 작업 내용</h2>
<h3>친구 피드 개선</h3>
<ul>
<li>친구 피드에서 <strong>진행 중 챌린지</strong>와 <strong>오늘 인증 여부</strong>를 반환하도록 수정
<ul>
<li>기존: 최근 인증 로그 중심 → 며칠 전 인증도 오늘 인증처럼 보일 여지 있음</li>
<li>변경: <code>certified_today: true / false</code> 구분으로 프론트에서 정확한 문구 표시 가능</li>
</ul>
</li>
</ul>
<h3>응원하기 기능 추가</h3>
<ul>
<li>친구에게 <strong>하루 1회</strong> 응원하기 기능 추가
<ul>
<li>응원 대상: <code>target_user_id</code> 기준</li>
<li><code>challenge_log_id</code>가 있으면 인증 로그와 함께 저장 가능</li>
<li>"친구의 하루를 응원"하는 UX에 맞춰 동일 친구에게 하루 1회만 응원 가능</li>
</ul>
</li>
</ul>
<h3>소셜 알림 저장</h3>
<ul>
<li>응원 시 <code>social_notifications</code> 모델에 알림 DB 저장
<ul>
<li><code>sender_id</code>, <code>receiver_id</code> 저장 → 누가 응원했는지 확인 가능</li>
<li>관련 인증이 있는 경우 <code>challenge_log_id</code> 함께 저장</li>
</ul>
</li>
</ul>
<h3>알림 조회 API 추가</h3>
<ul>
<li><code>GET /api/v1/social/feed/notifications</code>
<ul>
<li>sender 정보, 메시지, challenge title, 읽음 여부, 생성 시간 반환</li>
<li>프론트 응원 알림 탭 구성 가능</li>
</ul>
</li>
</ul>
<h3>버그 수정</h3>
<ul>
<li>내 진행 중 챌린지 조회 API JSON 직렬화 오류 수정
<ul>
<li><code>model_dump(mode="json")</code> 적용 → <code>date</code>, <code>datetime</code>, <code>enum</code> 값의 500 오류 방지</li>
</ul>
</li>
</ul>
<h3>nginx 업로드 제한 확장</h3>
<ul>
<li>건강검진표 OCR 업로드 시 nginx 차단 방지를 위해 업로드 제한 <strong>20MB</strong>로 증가
<ul>
<li><code>client_max_body_size 20M;</code> → default / prod http / prod https 설정에 반영</li>
</ul>
</li>
</ul>
<hr>
<h2>🔄 변경 파일</h2>

파일 | 변경 내용
-- | --
backend/app/models/social_notifications.py | SocialNotification 모델 신규 추가 (receiver_id, sender_id, challenge_log_id, type, message, read_at, created_at)
backend/app/models/__init__.py | SocialNotification 모델 등록 (서버 시작 시 테이블 자동 생성 대상 포함)
backend/app/dtos/social.py | CheerRequest, CheerResponse, FeedNotificationResponse, FeedNotificationListResponse 추가. FeedItemResponse에 challenge_id, user_challenge_id, challenge_log_id, certified_today 추가
backend/app/repositories/social_repository.py | 친구 피드 쿼리를 "진행 중 챌린지 + 오늘 인증 여부" 기준으로 변경. 응원 알림 생성/조회/중복 방지 쿼리 추가
backend/app/services/social.py | 응원하기 비즈니스 로직 구현 (본인/비친구/중복 응원 방지, 알림 생성, 알림 조회)
backend/app/apis/v1/social_routers.py | POST /api/v1/social/feed/cheer request body 수신으로 변경. GET /api/v1/social/feed/notifications 추가
backend/app/apis/v1/challenge_routers.py | 내 챌린지 조회 응답을 model_dump(mode="json")으로 변경하여 500 오류 방지
nginx/default.conf | client_max_body_size 20M; 추가
nginx/prod_http.conf | client_max_body_size 20M; 추가
nginx/prod_https.conf | client_max_body_size 20M; 추가


<hr>
<h2>✅ 테스트</h2>
<h3>추가 확인 필요</h3>
<ul>
<li>[ ] FastAPI 서버 재시작 후 <code>social_notifications</code> 테이블 생성 여부 확인</li>
<li>[ ] 친구 A → 친구 B 응원 시 알림 생성 확인</li>
<li>[ ] 같은 친구에게 같은 날 두 번째 응원 시 중복 응원 메시지 반환 확인</li>
<li>[ ] 친구가 아닌 사용자에게 응원 시 <code>403</code> 반환 확인</li>
<li>[ ] 본인에게 응원 시 <code>400</code> 반환 확인</li>
<li>[ ] 프론트 응원 알림 탭에서 받은 알림 표시 확인</li>
<li>[ ] 20MB 이하 OCR 파일 업로드 확인</li>
</ul>
<hr>
<h2>🔗 관련 평가 항목</h2>
<ul>
<li><strong>친구/소셜 기능 완성도</strong> — 친구 피드 인증 여부 정확 표시, 응원하기 → 실제 알림 연동</li>
<li><strong>API 설계 및 백엔드 연동</strong> — 응원 요청 API + 알림 조회 API 추가</li>
<li><strong>사용자 경험 개선</strong> — 챌린지 단위가 아닌 "친구의 하루를 응원"하는 UX로 단순화</li>
<li><strong>오류 개선</strong> — 챌린지 목록 조회 JSON 직렬화 500 오류 수정</li>
<li><strong>파일 업로드 안정성</strong> — OCR 파일 크기로 인한 nginx 차단 문제 해소</li>
</ul>
<hr>
<h2>📝 리뷰어에게</h2>
<h3>설계 의도</h3>
<p><strong><code>target_user_id</code>를 필수값으로 설정한 이유</strong></p>
<p>챌린지를 진행하지 않는 친구도 응원할 수 있어야 하고, 챌린지가 여러 개인 경우에도 "친구의 하루를 응원한다"는 UX가 더 자연스럽기 때문에 <code>challenge_log_id</code>가 아닌 <code>target_user_id</code>를 기준으로 삼았습니다.</p>
<p><strong><code>challenge_log_id</code>는 선택값</strong></p>
<ul>
<li>오늘 인증한 챌린지가 있으면 어떤 인증에 대한 응원인지 연결 가능</li>
<li>인증이 없거나 단순 친구 응원이면 <code>target_user_id</code>만으로 알림 생성</li>
</ul>
<p><strong>하루 1회 응원 제한</strong></p>
<p>알림 도배를 막고 응원하기 버튼의 의미를 유지하기 위한 제한입니다.</p>
<h3>테이블 자동 생성 관련</h3>
<p><code>social_notifications</code> 테이블은 SQLAlchemy 모델로 추가 후 <code>models/__init__.py</code>에 등록했습니다. 현재 프로젝트는 서버 시작 시 <code>Base.metadata.create_all</code>을 실행하는 구조이므로, <strong>서버 재시작 시 없는 테이블은 자동 생성</strong>됩니다. </p></body></html><!--EndFragment-->
</body>
</html>